### PR TITLE
Add framelimiting and framerate counter

### DIFF
--- a/src/qt/emuwindow.cpp
+++ b/src/qt/emuwindow.cpp
@@ -109,8 +109,10 @@ double EmuWindow::getFrameRate()
 
 void EmuWindow::updateWindowTitle()
 {
-    //Updates window title every second
-    //Framerate displayed is the average framerate over 1 second
+    /*
+    Updates window title every second
+    Framerate displayed is the average framerate over 1 second
+    */
     chrono::system_clock::time_point now = chrono::system_clock::now();
     chrono::duration<double> elapsed_update_seconds = now - old_update_time;
 
@@ -123,6 +125,13 @@ void EmuWindow::updateWindowTitle()
         setWindowTitle(QString::fromStdString(new_title));
         old_update_time = chrono::system_clock::now();
         framerate_avg = framerate;
+    }
+}
+
+void EmuWindow::limitFrameRate()
+{
+    while (getFrameRate() > 60.0)
+    {
     }
 }
 

--- a/src/qt/emuwindow.cpp
+++ b/src/qt/emuwindow.cpp
@@ -1,7 +1,9 @@
 #include <fstream>
 #include <iostream>
+#include <tgmath.h>
 
 #include <QPainter>
+#include <QString>
 #include "emuwindow.hpp"
 
 using namespace std;
@@ -14,7 +16,9 @@ ifstream::pos_type filesize(const char* filename)
 
 EmuWindow::EmuWindow(QWidget *parent) : QMainWindow(parent)
 {
-
+    old_frametime = chrono::system_clock::now();
+    old_update_time = chrono::system_clock::now();
+    framerate_avg = 0.0;
 }
 
 int EmuWindow::init(const char* bios_name, const char* file_name)
@@ -93,4 +97,36 @@ void EmuWindow::closeEvent(QCloseEvent *event)
 {
     event->accept();
     is_running = false;
+}
+
+double EmuWindow::getFrameRate()
+{
+    //Returns the framerate since old_frametime was set to the current time
+    chrono::system_clock::time_point now = chrono::system_clock::now();
+    chrono::duration<double> elapsed_seconds = now - old_frametime;
+    return (1 / elapsed_seconds.count());
+}
+
+void EmuWindow::updateWindowTitle()
+{
+    //Updates window title every second
+    //Framerate displayed is the average framerate over 1 second
+    chrono::system_clock::time_point now = chrono::system_clock::now();
+    chrono::duration<double> elapsed_update_seconds = now - old_update_time;
+
+    double framerate = getFrameRate();
+    framerate_avg = (framerate_avg + framerate) / 2;
+    if (elapsed_update_seconds.count() >= 1.0)
+    {
+        int rf = (int) round(framerate_avg); // rounded framerate
+        string new_title = "DobieStation - FPS: " + to_string(rf);
+        setWindowTitle(QString::fromStdString(new_title));
+        old_update_time = chrono::system_clock::now();
+        framerate_avg = framerate;
+    }
+}
+
+void EmuWindow::resetFrameTime()
+{
+    old_frametime = chrono::system_clock::now();
 }

--- a/src/qt/emuwindow.cpp
+++ b/src/qt/emuwindow.cpp
@@ -1,6 +1,6 @@
 #include <fstream>
 #include <iostream>
-#include <tgmath.h>
+#include <cmath>
 
 #include <QPainter>
 #include <QString>
@@ -130,9 +130,7 @@ void EmuWindow::update_window_title()
 
 void EmuWindow::limit_frame_rate()
 {
-    while (get_frame_rate() > 60.0)
-    {
-    }
+    while (get_frame_rate() > 60.0);
 }
 
 void EmuWindow::reset_frame_time()

--- a/src/qt/emuwindow.cpp
+++ b/src/qt/emuwindow.cpp
@@ -99,7 +99,7 @@ void EmuWindow::closeEvent(QCloseEvent *event)
     is_running = false;
 }
 
-double EmuWindow::getFrameRate()
+double EmuWindow::get_frame_rate()
 {
     //Returns the framerate since old_frametime was set to the current time
     chrono::system_clock::time_point now = chrono::system_clock::now();
@@ -107,7 +107,7 @@ double EmuWindow::getFrameRate()
     return (1 / elapsed_seconds.count());
 }
 
-void EmuWindow::updateWindowTitle()
+void EmuWindow::update_window_title()
 {
     /*
     Updates window title every second
@@ -116,7 +116,7 @@ void EmuWindow::updateWindowTitle()
     chrono::system_clock::time_point now = chrono::system_clock::now();
     chrono::duration<double> elapsed_update_seconds = now - old_update_time;
 
-    double framerate = getFrameRate();
+    double framerate = get_frame_rate();
     framerate_avg = (framerate_avg + framerate) / 2;
     if (elapsed_update_seconds.count() >= 1.0)
     {
@@ -128,14 +128,14 @@ void EmuWindow::updateWindowTitle()
     }
 }
 
-void EmuWindow::limitFrameRate()
+void EmuWindow::limit_frame_rate()
 {
-    while (getFrameRate() > 60.0)
+    while (get_frame_rate() > 60.0)
     {
     }
 }
 
-void EmuWindow::resetFrameTime()
+void EmuWindow::reset_frame_time()
 {
     old_frametime = chrono::system_clock::now();
 }

--- a/src/qt/emuwindow.hpp
+++ b/src/qt/emuwindow.hpp
@@ -25,6 +25,7 @@ class EmuWindow : public QMainWindow
         void closeEvent(QCloseEvent *event);
         double getFrameRate();
         void updateWindowTitle();
+        void limitFrameRate();
         void resetFrameTime();
     signals:
 

--- a/src/qt/emuwindow.hpp
+++ b/src/qt/emuwindow.hpp
@@ -23,10 +23,11 @@ class EmuWindow : public QMainWindow
 
         void paintEvent(QPaintEvent *event);
         void closeEvent(QCloseEvent *event);
-        double getFrameRate();
-        void updateWindowTitle();
-        void limitFrameRate();
-        void resetFrameTime();
+
+        double get_frame_rate();
+        void update_window_title();
+        void limit_frame_rate();
+        void reset_frame_time();
     signals:
 
     public slots:

--- a/src/qt/emuwindow.hpp
+++ b/src/qt/emuwindow.hpp
@@ -12,6 +12,9 @@ class EmuWindow : public QMainWindow
     private:
         Emulator e;
         bool is_running;
+        std::chrono::system_clock::time_point old_frametime;
+        std::chrono::system_clock::time_point old_update_time;
+        double framerate_avg;
     public:
         explicit EmuWindow(QWidget *parent = nullptr);
         int init(const char* bios_name, const char* ELF_name);
@@ -20,6 +23,9 @@ class EmuWindow : public QMainWindow
 
         void paintEvent(QPaintEvent *event);
         void closeEvent(QCloseEvent *event);
+        double getFrameRate();
+        void updateWindowTitle();
+        void resetFrameTime();
     signals:
 
     public slots:

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -19,15 +19,15 @@ int main(int argc, char** argv)
         printf("Arguments: bios_file ELF_file\n");
         return 0;
     }
-    bool limitFramerate = true;
+    bool enable_frame_rate_limiting = true;
     while (window->running())
     {
         a.processEvents();
         window->emulate();
-        if (limitFramerate)
-            window->limitFrameRate();
-        window->updateWindowTitle();
-        window->resetFrameTime();
+        if (enable_frame_rate_limiting)
+            window->limit_frame_rate();
+        window->update_window_title();
+        window->reset_frame_time();
     }
 
     return 0;

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -19,10 +19,24 @@ int main(int argc, char** argv)
         printf("Arguments: bios_file ELF_file\n");
         return 0;
     }
+    bool limitFramerate = true;
     while (window->running())
     {
-        a.processEvents();
+        //Loop a.processEvents() while instantaneous framerate exceeds 60
+        //Only if limit framerate is true
+        if (limitFramerate) 
+        {
+            do 
+                a.processEvents();
+            while (window->getFrameRate() > 60.0);
+        } 
+        else 
+            a.processEvents();
+        
         window->emulate();
+        window->updateWindowTitle();
+        window->resetFrameTime();
+        
     }
 
     return 0;

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -22,8 +22,6 @@ int main(int argc, char** argv)
     bool limitFramerate = true;
     while (window->running())
     {
-        //Loop a.processEvents() while instantaneous framerate exceeds 60
-        //Only if limit framerate is true
         a.processEvents();
         window->emulate();
         if (limitFramerate)

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -24,19 +24,12 @@ int main(int argc, char** argv)
     {
         //Loop a.processEvents() while instantaneous framerate exceeds 60
         //Only if limit framerate is true
-        if (limitFramerate) 
-        {
-            do 
-                a.processEvents();
-            while (window->getFrameRate() > 60.0);
-        } 
-        else 
-            a.processEvents();
-        
+        a.processEvents();
         window->emulate();
+        if (limitFramerate)
+            window->limitFrameRate();
         window->updateWindowTitle();
         window->resetFrameTime();
-        
     }
 
     return 0;


### PR DESCRIPTION
This adds framelimiting as well as a framerate counter in the window title. 

Framelimiting is toggled by the variable `limitFramerate`, which may be used in future functionality.
Framelimiting is achieved by an empty while loop in the `EmuWindow::limitFrameRate()` function in `emuwindow.cpp`, and is called in the main loop.

The framerate counter displays the framerate in the window title. It updates every 1 second, and displays the average framerate over that second. This behaviour is done in the `EmuWindow::updateWindowTitle()`.