### PR TITLE
Flatpak cmake

### DIFF
--- a/dist/com.github.psi_rockin.DobieStation.json
+++ b/dist/com.github.psi_rockin.DobieStation.json
@@ -1,0 +1,34 @@
+{
+  "app-id": "com.github.psi_rockin.DobieStation",
+  "runtime": "org.kde.Platform",
+  "runtime-version": "5.9",
+  "sdk": "org.kde.Sdk",
+  "command": "DobieStation",
+  "finish-args": [
+    "--device=all",
+    "--filesystem=home:ro",
+    "--socket=pulseaudio",
+    "--socket=x11"
+  ],
+  "modules": [
+    {
+      "name": "DobieStation",
+      "buildsystem": "cmake",
+      "no-make-install": true,
+      "build-commands": [
+        "mkdir /app/bin",
+        "install DobieStation /app/bin/"
+      ],
+      "sources": [
+        {
+          "type": "git",
+          "url": "https://github.com/PSI-Rockin/DobieStation.git"
+        },
+        {
+          "type": "shell",
+          "commands": ["rm -rf DobieStation"]
+        }
+      ]
+    }
+  ]
+}

--- a/dist/com.github.psi_rockin.DobieStation.json
+++ b/dist/com.github.psi_rockin.DobieStation.json
@@ -15,6 +15,7 @@
       "name": "DobieStation",
       "buildsystem": "cmake",
       "no-make-install": true,
+      "builddir": true,
       "build-commands": [
         "mkdir /app/bin",
         "install DobieStation /app/bin/"
@@ -23,10 +24,6 @@
         {
           "type": "git",
           "url": "https://github.com/PSI-Rockin/DobieStation.git"
-        },
-        {
-          "type": "shell",
-          "commands": ["rm -rf DobieStation"]
         }
       ]
     }


### PR DESCRIPTION
This file allows for building DobieStation inside a flatpak container.
It's helpful for people who may want to build it in a cleaner way without
having to install the qt dependencies. I have made it use cmake internally,
this way it won't need much maintenance as long as cmake keeps being updated.

Once DobieStation becomes more mature, this file can also be used to produce
linux builds that work on any linux distribution.