### PR TITLE
Added gouraud shading to relevant primitives

### DIFF
--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -110,6 +110,11 @@ void Emulator::get_resolution(int &w, int &h)
     gs.get_resolution(w, h);
 }
 
+void Emulator::get_inner_resolution(int &w, int &h)
+{
+    gs.get_inner_resolution(w, h);
+}
+
 bool Emulator::skip_BIOS()
 {
     //hax

--- a/src/core/emulator.hpp
+++ b/src/core/emulator.hpp
@@ -66,6 +66,7 @@ class Emulator
         void execute_ELF();
         uint32_t* get_framebuffer();
         void get_resolution(int& w, int& h);
+        void get_inner_resolution(int& w, int& h);
 
         uint8_t read8(uint32_t address);
         uint16_t read16(uint32_t address);

--- a/src/core/gs.hpp
+++ b/src/core/gs.hpp
@@ -89,7 +89,9 @@ struct Vertex
 struct Point
 {
     int32_t x, y, z;
-    Point(int32_t _x, int32_t _y, int32_t _z = 0) : x(_x), y(_y), z(_z) {}
+    uint8_t r, g, b, a;
+    Point(int32_t _x, int32_t _y, int32_t _z = 0, uint8_t _r = 0, uint8_t _g = 0, uint8_t _b = 0, uint8_t _a = 0)
+        : x(_x), y(_y), z(_z), r(_r), g(_g), b(_b), a(_a) {}
 };
 
 class INTC;
@@ -156,6 +158,7 @@ class GraphicsSynthesizer
         uint32_t* get_framebuffer();
         void render_CRT();
         void get_resolution(int& w, int& h);
+        void get_inner_resolution(int& w, int& h);
 
         void set_VBLANK(bool is_VBLANK);
 

--- a/src/qt/emuwindow.cpp
+++ b/src/qt/emuwindow.cpp
@@ -98,8 +98,9 @@ void EmuWindow::paintEvent(QPaintEvent *event)
     painter.fillRect(rect(), Qt::black);
     if (!buffer)
         return;
-
-    QImage image((uint8_t*)buffer, 640, 256, QImage::Format_RGBA8888);
+    int inner_w, inner_h;
+    e.get_inner_resolution(inner_w, inner_h);
+    QImage image((uint8_t*)buffer, inner_w, inner_h, QImage::Format_RGBA8888);
 
     int new_w, new_h;
     e.get_resolution(new_w, new_h);


### PR DESCRIPTION
Gouraud shading is now implemented as well, thanks to the method adopted in #26, interpolation of colors was trivial.

Cubemastah's cube are rendering correctly, though the blinking caused by double buffering is still an issue.
[GIF for reference](https://imgur.com/C9Llrcw).

Also added a workaround to fix the slanting in some of the demos.