### PR TITLE
Load ELF in Menu Bar

### DIFF
--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -186,6 +186,9 @@ void Emulator::set_skip_BIOS_hack(SKIP_HACK type)
 
 void Emulator::load_BIOS(uint8_t *BIOS_file)
 {
+    if (!BIOS)
+        BIOS = new uint8_t[1024 * 1024 * 4];
+
     memcpy(BIOS, BIOS_file, 1024 * 1024 * 4);
 }
 

--- a/src/qt/emuwindow.cpp
+++ b/src/qt/emuwindow.cpp
@@ -7,7 +7,6 @@
 #include <QVBoxLayout>
 #include <QMenuBar>
 #include <QFileDialog>
-#include <QThread>
 
 #include "emuwindow.hpp"
 

--- a/src/qt/emuwindow.cpp
+++ b/src/qt/emuwindow.cpp
@@ -41,9 +41,6 @@ EmuWindow::EmuWindow(QWidget *parent) : QMainWindow(parent)
     widget->setLayout(layout);
 
     create_menu();
-    
-    activateWindow();
-    raise();
 }
 
 int EmuWindow::init(int argc, char** argv)

--- a/src/qt/emuwindow.cpp
+++ b/src/qt/emuwindow.cpp
@@ -55,13 +55,10 @@ int EmuWindow::init(int argc, char** argv)
     e.reset();
     char* bios_name = argv[1];
 
-	/*
-	 * TODO: make a better conditional
-	 */
 	char* file_name;
 	if(argc == 4)
 		file_name = argv[2];
-	else if(argc == 3 && !strcmp(argv[2], "-skip"))
+	else if(argc == 3 && strcmp(argv[2], "-skip") != 0)
 		file_name = argv[2];
 	else
 		file_name = nullptr;
@@ -102,8 +99,6 @@ int EmuWindow::init(int argc, char** argv)
 		{
 			return 1;
 		}
-
-		is_exec_loaded = true;
 	}
 	else
 	{

--- a/src/qt/emuwindow.cpp
+++ b/src/qt/emuwindow.cpp
@@ -9,6 +9,7 @@
 #include <QFileDialog>
 
 #include "emuwindow.hpp"
+#include <QApplication>
 
 using namespace std;
 
@@ -40,6 +41,9 @@ EmuWindow::EmuWindow(QWidget *parent) : QMainWindow(parent)
     widget->setLayout(layout);
 
     create_menu();
+    
+    activateWindow();
+    raise();
 }
 
 int EmuWindow::init(int argc, char** argv)
@@ -51,7 +55,6 @@ int EmuWindow::init(int argc, char** argv)
     }
 
     //Initialize emulator
-    e.reset();
     char* bios_name = argv[1];
 
     char* file_name;
@@ -114,6 +117,8 @@ int EmuWindow::init(int argc, char** argv)
 
 int EmuWindow::load_exec(const char* file_name, bool skip_BIOS)
 {
+    e.reset();
+
     ifstream exec_file(file_name, ios::binary | ios::in);
     if (!exec_file.is_open())
     {
@@ -278,11 +283,11 @@ void EmuWindow::contextMenuEvent(QContextMenuEvent* event)
 void EmuWindow::open_file_no_skip()
 {
     QString file_name = QFileDialog::getOpenFileName(this, tr("Open Rom"), "", tr("ROM Files (*.elf *.iso)"));
-    load_exec(file_name.toStdString().c_str(), true);
+    load_exec(file_name.toStdString().c_str(), false);
 }
 
 void EmuWindow::open_file_skip()
 {
     QString file_name = QFileDialog::getOpenFileName(this, tr("Open Rom"), "", tr("ROM Files (*.elf *.iso)"));
-    load_exec(file_name.toStdString().c_str(), false);
+    load_exec(file_name.toStdString().c_str(), true);
 }

--- a/src/qt/emuwindow.cpp
+++ b/src/qt/emuwindow.cpp
@@ -9,7 +9,6 @@
 #include <QFileDialog>
 
 #include "emuwindow.hpp"
-#include <QApplication>
 
 using namespace std;
 
@@ -51,13 +50,12 @@ int EmuWindow::init(int argc, char** argv)
         return 1;
     }
 
-    //Initialize emulator
     char* bios_name = argv[1];
 
     char* file_name;
-    if(argc == 4)
+    if (argc == 4)
         file_name = argv[2];
-    else if(argc == 3 && strcmp(argv[2], "-skip") != 0)
+    else if (argc == 3 && strcmp(argv[2], "-skip") != 0)
         file_name = argv[2];
     else
         file_name = nullptr;
@@ -66,12 +64,12 @@ int EmuWindow::init(int argc, char** argv)
     //Flag parsing - to be reworked
     if (argc >= 3)
     {
-        if(argc == 3)
+        if (argc == 3)
         {
             if (strcmp(argv[2], "-skip") == 0)
                 skip_BIOS = true;
         } 
-        else if(argc == 4)
+        else if (argc == 4)
         {
             if (strcmp(argv[3], "-skip") == 0)
                 skip_BIOS = true;
@@ -92,12 +90,10 @@ int EmuWindow::init(int argc, char** argv)
     delete[] BIOS;
     BIOS = nullptr;
 
-    if(file_name)
+    if (file_name)
     {
-        if(load_exec(file_name, skip_BIOS))
-        {
+        if (load_exec(file_name, skip_BIOS))
             return 1;
-        }
     }
     else
     {
@@ -179,18 +175,18 @@ void EmuWindow::emulate()
 
 void EmuWindow::create_menu()
 {
-    open_action = new QAction(tr("&Open Rom"), this);
-    connect(open_action, &QAction::triggered, this, &EmuWindow::open_file_no_skip);
+    load_rom_action = new QAction(tr("&Load Rom..."), this);
+    connect(load_rom_action, &QAction::triggered, this, &EmuWindow::open_file_skip);
 
-    open_action_skip = new QAction(tr("&Open Rom (Skip BIOS)"), this);
-    connect(open_action_skip, &QAction::triggered, this, &EmuWindow::open_file_skip);
+    load_bios_action = new QAction(tr("&Load BIOS..."), this);
+    connect(load_bios_action, &QAction::triggered, this, &EmuWindow::open_file_no_skip);
 
     exit_action = new QAction(tr("&Exit"), this);
     connect(exit_action, &QAction::triggered, this, &QWidget::close);
 
     file_menu = menuBar()->addMenu(tr("&File"));
-    file_menu->addAction(open_action);
-    file_menu->addAction(open_action_skip);
+    file_menu->addAction(load_rom_action);
+    file_menu->addAction(load_bios_action);
     file_menu->addAction(exit_action);
 }
 
@@ -271,7 +267,8 @@ void EmuWindow::reset_frame_time()
 void EmuWindow::contextMenuEvent(QContextMenuEvent* event)
 {
     QMenu menu(this);
-    menu.addAction(open_action);
+    menu.addAction(load_rom_action);
+    menu.addAction(load_bios_action);
     menu.addAction(exit_action);
     menu.exec(event->globalPos());
 }

--- a/src/qt/emuwindow.cpp
+++ b/src/qt/emuwindow.cpp
@@ -178,7 +178,7 @@ void EmuWindow::create_menu()
     load_rom_action = new QAction(tr("&Load Rom... (Fast)"), this);
     connect(load_rom_action, &QAction::triggered, this, &EmuWindow::open_file_skip);
 
-    load_bios_action = new QAction(tr("&Load ROM... (Boot BIOS"), this);
+    load_bios_action = new QAction(tr("&Load ROM... (Boot BIOS)"), this);
     connect(load_bios_action, &QAction::triggered, this, &EmuWindow::open_file_no_skip);
 
     exit_action = new QAction(tr("&Exit"), this);

--- a/src/qt/emuwindow.cpp
+++ b/src/qt/emuwindow.cpp
@@ -175,7 +175,7 @@ void EmuWindow::emulate()
 
 void EmuWindow::create_menu()
 {
-    load_rom_action = new QAction(tr("&Load Rom... (Fast)"), this);
+    load_rom_action = new QAction(tr("&Load ROM... (Fast)"), this);
     connect(load_rom_action, &QAction::triggered, this, &EmuWindow::open_file_skip);
 
     load_bios_action = new QAction(tr("&Load ROM... (Boot BIOS)"), this);

--- a/src/qt/emuwindow.cpp
+++ b/src/qt/emuwindow.cpp
@@ -175,10 +175,10 @@ void EmuWindow::emulate()
 
 void EmuWindow::create_menu()
 {
-    load_rom_action = new QAction(tr("&Load Rom..."), this);
+    load_rom_action = new QAction(tr("&Load Rom... (Fast)"), this);
     connect(load_rom_action, &QAction::triggered, this, &EmuWindow::open_file_skip);
 
-    load_bios_action = new QAction(tr("&Load BIOS..."), this);
+    load_bios_action = new QAction(tr("&Load ROM... (Boot BIOS"), this);
     connect(load_bios_action, &QAction::triggered, this, &EmuWindow::open_file_no_skip);
 
     exit_action = new QAction(tr("&Exit"), this);

--- a/src/qt/emuwindow.hpp
+++ b/src/qt/emuwindow.hpp
@@ -14,14 +14,26 @@ class EmuWindow : public QMainWindow
     private:
         Emulator e;
         bool is_running;
+		bool is_exec_loaded;
         std::chrono::system_clock::time_point old_frametime;
         std::chrono::system_clock::time_point old_update_time;
         double framerate_avg;
+
+		QMenu* file_menu;
+		QAction* open_action;
+		QAction* open_action_skip;
+		QAction* exit_action;
     public:
         explicit EmuWindow(QWidget *parent = nullptr);
         int init(int argc, char** argv);
-        bool running();
+		int load_exec(const char* file_name, bool skip_BIOS);
+
+		bool exec_loaded();
+		bool running();
+
         void emulate();
+
+		void create_menu();
 
         void paintEvent(QPaintEvent *event);
         void closeEvent(QCloseEvent *event);
@@ -30,9 +42,17 @@ class EmuWindow : public QMainWindow
         void update_window_title();
         void limit_frame_rate();
         void reset_frame_time();
+
+	protected:
+	#ifndef QT_NO_CONTEXTMENU
+		void contextMenuEvent(QContextMenuEvent* event) override;
+	#endif
+	
     signals:
 
     public slots:
+		void open_file_no_skip();
+		void open_file_skip();
 };
 
 #endif // EMUWINDOW_HPP

--- a/src/qt/emuwindow.hpp
+++ b/src/qt/emuwindow.hpp
@@ -2,8 +2,6 @@
 #define EMUWINDOW_HPP
 
 #include <chrono>
-
-#include <QCloseEvent>
 #include <QMainWindow>
 #include <QPaintEvent>
 #include "../core/emulator.hpp"
@@ -20,8 +18,8 @@ class EmuWindow : public QMainWindow
         double framerate_avg;
 
         QMenu* file_menu;
-        QAction* open_action;
-        QAction* open_action_skip;
+        QAction* load_rom_action;
+        QAction* load_bios_action;
         QAction* exit_action;
 
     public:

--- a/src/qt/emuwindow.hpp
+++ b/src/qt/emuwindow.hpp
@@ -14,26 +14,27 @@ class EmuWindow : public QMainWindow
     private:
         Emulator e;
         bool is_running;
-		bool is_exec_loaded;
+        bool is_exec_loaded;
         std::chrono::system_clock::time_point old_frametime;
         std::chrono::system_clock::time_point old_update_time;
         double framerate_avg;
 
-		QMenu* file_menu;
-		QAction* open_action;
-		QAction* open_action_skip;
-		QAction* exit_action;
+        QMenu* file_menu;
+        QAction* open_action;
+        QAction* open_action_skip;
+        QAction* exit_action;
+
     public:
         explicit EmuWindow(QWidget *parent = nullptr);
         int init(int argc, char** argv);
-		int load_exec(const char* file_name, bool skip_BIOS);
+        int load_exec(const char* file_name, bool skip_BIOS);
 
-		bool exec_loaded();
-		bool running();
+        bool exec_loaded();
+        bool running();
 
         void emulate();
 
-		void create_menu();
+        void create_menu();
 
         void paintEvent(QPaintEvent *event);
         void closeEvent(QCloseEvent *event);
@@ -43,16 +44,16 @@ class EmuWindow : public QMainWindow
         void limit_frame_rate();
         void reset_frame_time();
 
-	protected:
-	#ifndef QT_NO_CONTEXTMENU
-		void contextMenuEvent(QContextMenuEvent* event) override;
-	#endif
-	
+    protected:
+    #ifndef QT_NO_CONTEXTMENU
+        void contextMenuEvent(QContextMenuEvent* event) override;
+    #endif
+    
     signals:
 
     public slots:
-		void open_file_no_skip();
-		void open_file_skip();
+        void open_file_no_skip();
+        void open_file_skip();
 };
 
 #endif // EMUWINDOW_HPP

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -13,7 +13,7 @@ int main(int argc, char** argv)
     while (window->running())
     {
         a.processEvents();
-        if(window->exec_loaded())
+        if (window->exec_loaded())
         {
             window->emulate();
             if (enable_frame_rate_limiting)

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -13,11 +13,14 @@ int main(int argc, char** argv)
     while (window->running())
     {
         a.processEvents();
-        window->emulate();
-        if (enable_frame_rate_limiting)
-            window->limit_frame_rate();
-        window->update_window_title();
-        window->reset_frame_time();
+		if(window->exec_loaded())
+		{
+			window->emulate();
+			if (enable_frame_rate_limiting)
+				window->limit_frame_rate();
+			window->update_window_title();
+			window->reset_frame_time();
+		}
     }
 
     return 0;

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -13,14 +13,14 @@ int main(int argc, char** argv)
     while (window->running())
     {
         a.processEvents();
-		if(window->exec_loaded())
-		{
-			window->emulate();
-			if (enable_frame_rate_limiting)
-				window->limit_frame_rate();
-			window->update_window_title();
-			window->reset_frame_time();
-		}
+        if(window->exec_loaded())
+        {
+            window->emulate();
+            if (enable_frame_rate_limiting)
+                window->limit_frame_rate();
+            window->update_window_title();
+            window->reset_frame_time();
+        }
     }
 
     return 0;


### PR DESCRIPTION
Added a menu bar to the main window.
Outsourced loading roms to it's own function.
Created three items in the menu bar to load the elf with or without bios skip and to exit the program.
This allows the program to start only with a bios path provided and the ROM can be loaded after.