### PR TITLE
Fixed assignment of the TEXCLUT register

### DIFF
--- a/src/core/gs.cpp
+++ b/src/core/gs.cpp
@@ -471,7 +471,7 @@ void GraphicsSynthesizer::write64(uint32_t addr, uint64_t value)
         case 0x001C:
             TEXCLUT.width = (value & 0x3F) * 64;
             TEXCLUT.x = ((value >> 6) & 0x3F) * 16;
-            TEXCLUT.y = (value >> 11) & 0x3FF;
+            TEXCLUT.y = (value >> 12) & 0x3FF;
             printf("TEXCLUT: $%08X\n", value);
             printf("Width: %d\n", TEXCLUT.width);
             printf("X: %d\n", TEXCLUT.x);


### PR DESCRIPTION
This incredibly minor change fixes the slightly messed up colors on the Atelier Iris: Eternal Mana memory card screen, and the cursor is no longer disappearing at times.

The fix of the colors can be seen on this picture.
![image](https://user-images.githubusercontent.com/1376083/41190265-b09d245c-6bdb-11e8-9862-ee9b29a95968.png)

Also, the GS Users' Manual (pg. 130) verifies that this is indeed the correct behaviour.
