### PR TITLE
Gsdump

### DIFF
--- a/src/core/circularFIFO.hpp
+++ b/src/core/circularFIFO.hpp
@@ -47,7 +47,7 @@ void CircularFifo<Element, Size>::push(const Element& item)
     }
     else
     {
-        Errors::print_warning("FIFO FULL!");
+        Errors::die("FIFO FULL!");
     }
 }
 

--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -55,7 +55,22 @@ void Emulator::run()
     {
         gsdump_requested = false;
         gs.send_dump_request();
+        gsdump_running = !gsdump_running;
     }
+    else if (gsdump_single_frame)
+    {
+        gs.send_dump_request();
+        if (gsdump_running)
+        {
+            gsdump_running = false;
+            gsdump_single_frame = false;
+        }
+        else
+        {
+            gsdump_running = true;
+        }
+    }
+    
     while (instructions_run < CYCLES_PER_FRAME)
     {
         int cycles = cpu.run(8);
@@ -1342,4 +1357,8 @@ GraphicsSynthesizer& Emulator::get_gs()
 void Emulator::request_gsdump_toggle()
 {
     gsdump_requested = true;
+}
+void Emulator::request_gsdump_single_frame()
+{
+    gsdump_single_frame = true;
 }

--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -45,9 +45,7 @@ void Emulator::run()
     if (gsdump_requested)
     {
         gsdump_requested = false;
-        GS_message_payload p;
-        p.no_payload = { 0 };
-        gs.send_message({ gsdump_t, p });
+        gs.send_dump_request();
     }
     gs.start_frame();
     instructions_run = 0;

--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -42,6 +42,13 @@ Emulator::~Emulator()
 
 void Emulator::run()
 {
+    if (gsdump_requested)
+    {
+        gsdump_requested = false;
+        GS_message_payload p;
+        p.no_payload = { 0 };
+        gs.send_message({ gsdump_t, p });
+    }
     gs.start_frame();
     instructions_run = 0;
     VBLANK_sent = false;
@@ -99,6 +106,7 @@ void Emulator::reset()
 {
     save_requested = false;
     load_requested = false;
+    gsdump_requested = false;
     iop_i_ctrl_delay = 0;
     ee_stdout = "";
     frames = 0;
@@ -1281,4 +1289,14 @@ void Emulator::iop_puts()
     }
     ee_log.flush();
     //printf("\n");
+}
+
+GraphicsSynthesizer& Emulator::get_gs()
+{
+    return gs;
+}
+
+void Emulator::request_gsdump_toggle()
+{
+    gsdump_requested = true;
 }

--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -42,11 +42,6 @@ Emulator::~Emulator()
 
 void Emulator::run()
 {
-    if (gsdump_requested)
-    {
-        gsdump_requested = false;
-        gs.send_dump_request();
-    }
     gs.start_frame();
     instructions_run = 0;
     VBLANK_sent = false;
@@ -56,6 +51,11 @@ void Emulator::run()
         save_state(savestate_path.c_str());
     if (load_requested)
         load_state(savestate_path.c_str());
+    if (gsdump_requested)
+    {
+        gsdump_requested = false;
+        gs.send_dump_request();
+    }
     while (instructions_run < CYCLES_PER_FRAME)
     {
         int cycles = cpu.run(8);

--- a/src/core/emulator.hpp
+++ b/src/core/emulator.hpp
@@ -33,7 +33,7 @@ enum SKIP_HACK
 class Emulator
 {
     private:
-        std::atomic_bool save_requested, load_requested, gsdump_requested;
+        std::atomic_bool save_requested, load_requested, gsdump_requested, gsdump_single_frame, gsdump_running;
         std::string savestate_path;
         int frames;
         Cop0 cp0;
@@ -106,6 +106,7 @@ class Emulator
         bool request_load_state(const char* file_name);
         bool request_save_state(const char* file_name);
         void request_gsdump_toggle();
+        void request_gsdump_single_frame();
         void load_state(const char* file_name);
         void save_state(const char* file_name);
 

--- a/src/core/emulator.hpp
+++ b/src/core/emulator.hpp
@@ -33,7 +33,7 @@ enum SKIP_HACK
 class Emulator
 {
     private:
-        bool save_requested, load_requested, gsdump_requested;
+        std::atomic_bool save_requested, load_requested, gsdump_requested;
         std::string savestate_path;
         int frames;
         Cop0 cp0;

--- a/src/core/emulator.hpp
+++ b/src/core/emulator.hpp
@@ -33,7 +33,7 @@ enum SKIP_HACK
 class Emulator
 {
     private:
-        bool save_requested, load_requested;
+        bool save_requested, load_requested, gsdump_requested;
         std::string savestate_path;
         int frames;
         Cop0 cp0;
@@ -105,6 +105,7 @@ class Emulator
 
         bool request_load_state(const char* file_name);
         bool request_save_state(const char* file_name);
+        void request_gsdump_toggle();
         void load_state(const char* file_name);
         void save_state(const char* file_name);
 
@@ -134,6 +135,7 @@ class Emulator
         void iop_puts();
 
         void test_iop();
+        GraphicsSynthesizer& get_gs();//used for gs dumps
 };
 
 #endif // EMULATOR_HPP

--- a/src/core/gs.cpp
+++ b/src/core/gs.cpp
@@ -77,13 +77,6 @@ void GraphicsSynthesizer::reset()
 
 }
 
-void GraphicsSynthesizer::memdump()
-{
-    GS_message_payload payload;
-    payload.no_payload = { };
-    send_message({ GS_command::memdump_t,payload });
-}
-
 void GraphicsSynthesizer::start_frame()
 {
     frame_complete = false;
@@ -336,4 +329,10 @@ void GraphicsSynthesizer::save_state(ofstream &state)
 void GraphicsSynthesizer::send_message(GS_message message)
 {
     message_queue->push(message);
+}
+void GraphicsSynthesizer::send_dump_request()
+{
+    GS_message_payload p;
+    p.no_payload = { 0 };
+    send_message({ gsdump_t, p });
 }

--- a/src/core/gs.cpp
+++ b/src/core/gs.cpp
@@ -204,9 +204,19 @@ void GraphicsSynthesizer::render_CRT()
 {
     GS_message_payload payload;
     if (using_first_buffer)
-        payload.render_payload = { output_buffer1, &output_buffer1_mutex };
+        payload.render_payload = { output_buffer1, &output_buffer1_mutex, false };
     else
-        payload.render_payload = { output_buffer2, &output_buffer2_mutex }; ;
+        payload.render_payload = { output_buffer2, &output_buffer2_mutex, false }; ;
+    send_message({ GS_command::render_crt_t,payload });
+}
+
+void GraphicsSynthesizer::render_partial_frame()
+{
+    GS_message_payload payload;
+    if (using_first_buffer)
+        payload.render_payload = { output_buffer1, &output_buffer1_mutex, true };
+    else
+        payload.render_payload = { output_buffer2, &output_buffer2_mutex, true }; ;
     send_message({ GS_command::render_crt_t,payload });
 }
 

--- a/src/core/gs.hpp
+++ b/src/core/gs.hpp
@@ -15,7 +15,7 @@ enum GS_command:uint8_t
 	write64_t, write64_privileged_t, write32_privileged_t,
     set_rgba_t, set_stq_t, set_uv_t, set_xyz_t, set_q_t, set_crt_t,
     render_crt_t, assert_finish_t, set_vblank_t, memdump_t, die_t,
-    savestate_t, loadstate_t, gsdump_t,
+    savestate_t, loadstate_t, gsdump_t
 };
 
 union GS_message_payload 
@@ -65,6 +65,7 @@ union GS_message_payload
 	{
         uint32_t* target;
         std::mutex* target_mutex;
+        bool invert; //invert to look at in-progress frame buffer
     } render_payload;
     struct
     {
@@ -143,6 +144,7 @@ class GraphicsSynthesizer
         bool is_frame_complete();
         uint32_t* get_framebuffer();
         void render_CRT();
+        void render_partial_frame();
         void get_resolution(int& w, int& h);
         void get_inner_resolution(int& w, int& h);
 

--- a/src/core/gs.hpp
+++ b/src/core/gs.hpp
@@ -165,6 +165,7 @@ class GraphicsSynthesizer
 
         void load_state(std::ifstream& state);
         void save_state(std::ofstream& state);
+        void send_message(GS_message message);
 };
 
 #endif // GS_HPP

--- a/src/core/gs.hpp
+++ b/src/core/gs.hpp
@@ -65,7 +65,6 @@ union GS_message_payload
 	{
         uint32_t* target;
         std::mutex* target_mutex;
-        bool invert; //invert to look at in-progress frame buffer
     } render_payload;
     struct
     {
@@ -93,7 +92,8 @@ enum GS_return :uint8_t
     render_complete_t,
     death_error_t,
     savestate_done_t,
-    loadstate_done_t
+    loadstate_done_t,
+    gsdump_render_partial_done_t,
 };
 
 union GS_return_message_payload
@@ -102,6 +102,10 @@ union GS_return_message_payload
     {
         const char* error_str;
     } death_error_payload;
+    struct
+    {
+        uint16_t x, y;
+    } xy_payload;
     struct
     {
         uint8_t BLANK;
@@ -144,7 +148,7 @@ class GraphicsSynthesizer
         bool is_frame_complete();
         uint32_t* get_framebuffer();
         void render_CRT();
-        void render_partial_frame();
+        uint32_t* render_partial_frame(uint16_t& width, uint16_t& height);
         void get_resolution(int& w, int& h);
         void get_inner_resolution(int& w, int& h);
 

--- a/src/core/gs.hpp
+++ b/src/core/gs.hpp
@@ -15,7 +15,7 @@ enum GS_command:uint8_t
 	write64_t, write64_privileged_t, write32_privileged_t,
     set_rgba_t, set_stq_t, set_uv_t, set_xyz_t, set_q_t, set_crt_t,
     render_crt_t, assert_finish_t, set_vblank_t, memdump_t, die_t,
-    savestate_t, loadstate_t
+    savestate_t, loadstate_t, gsdump_t,
 };
 
 union GS_message_payload 

--- a/src/core/gs.hpp
+++ b/src/core/gs.hpp
@@ -142,8 +142,8 @@ class GraphicsSynthesizer
     public:
         GraphicsSynthesizer(INTC* intc);
         ~GraphicsSynthesizer();
+        void send_message(GS_message message);
         void reset();
-        void memdump();
         void start_frame();
         bool is_frame_complete();
         uint32_t* get_framebuffer();
@@ -171,7 +171,8 @@ class GraphicsSynthesizer
 
         void load_state(std::ifstream& state);
         void save_state(std::ofstream& state);
-        void send_message(GS_message message);
+        void send_dump_request();
+        
 };
 
 #endif // GS_HPP

--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -223,7 +223,6 @@ void GraphicsSynthesizerThread::event_loop(gs_fifo* fifo, gs_return_fifo* return
                         uint16_t width, height;
                         gs.memdump(p.target, width, height);
                         GS_return_message_payload return_payload;
-                        SCISSOR s = gs.current_ctx->scissor;
                         return_payload.xy_payload = { width, height };
                         return_fifo->push({ GS_return::gsdump_render_partial_done_t,return_payload });
                         break;

--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -196,7 +196,7 @@ void GraphicsSynthesizerThread::event_loop(gs_fifo* fifo, gs_return_fifo* return
                             std::this_thread::yield();
                         }
                         std::lock_guard<std::mutex> lock(*p.target_mutex, std::adopt_lock);
-                        gs.render_CRT(p.target);
+                        gs.render_CRT(p.target, p.invert);
                         GS_return_message_payload return_payload;
                         return_payload.no_payload = { 0 };
                         return_fifo->push({ GS_return::render_complete_t,return_payload });
@@ -295,12 +295,12 @@ void GraphicsSynthesizerThread::memdump()
     file.close();
 }
 
-void GraphicsSynthesizerThread::render_CRT(uint32_t* target)
+void GraphicsSynthesizerThread::render_CRT(uint32_t* target, bool invert)
 {
     printf("DISPLAY2: (%d, %d) wh: (%d, %d)\n", reg.DISPLAY2.x >> 2, reg.DISPLAY2.y, reg.DISPLAY2.width >> 2, reg.DISPLAY2.height);
     DISPLAY &currentDisplay = reg.DISPLAY1;
     DISPFB &currentFB = reg.DISPFB1;
-    if (reg.PMODE.circuit2 == false)
+    if (reg.PMODE.circuit2 == invert)
     {
         currentDisplay = reg.DISPLAY1;
         currentFB = reg.DISPFB1;

--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -234,16 +234,26 @@ void GraphicsSynthesizerThread::event_loop(gs_fifo* fifo, gs_return_fifo* return
                     }
                     case gsdump_t:
                     {
-                        if (gsdump_recording) {
+                        printf("gs dump! ");
+                        if (!gsdump_recording) {
+                            printf("(start)\n");
                             gsdump_file.open("gsdump.gsd", ios::out | ios::binary);
+                            if (!gsdump_file.is_open())
+                                Errors::die("gs dump file failed to open");
                             gsdump_recording = true;
                             gs.save_state(&gsdump_file);
+                            gsdump_file.write((char*)&gs.reg, sizeof(gs.reg));//this is for the emuthread's gs faker
                         }
-                        else {
+                        else
+                        {
+                            printf("(end)\n");
                             gsdump_file.close();
                             gsdump_recording = false;
                         }
+                        break;
                     }
+                    default:
+                        Errors::die("corrupted command sent to GS thread");
                 }
             }
             else

--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -127,9 +127,8 @@ void GraphicsSynthesizerThread::event_loop(gs_fifo* fifo, gs_return_fifo* return
             bool available = fifo->pop(data);
             if (available)
             {
-                if (gsdump_recording) {
+                if (gsdump_recording)
                     gsdump_file.write((char*)&data, sizeof(data));
-                }
                 switch (data.type)
                 {
                     case write64_t:
@@ -250,7 +249,8 @@ void GraphicsSynthesizerThread::event_loop(gs_fifo* fifo, gs_return_fifo* return
                     case gsdump_t:
                     {
                         printf("gs dump! ");
-                        if (!gsdump_recording) {
+                        if (!gsdump_recording)
+                        {
                             printf("(start)\n");
                             gsdump_file.open("gsdump.gsd", ios::out | ios::binary);
                             if (!gsdump_file.is_open())

--- a/src/core/gsthread.hpp
+++ b/src/core/gsthread.hpp
@@ -190,8 +190,8 @@ class GraphicsSynthesizerThread
 
         //called from event loop
         void reset();
-        void memdump();
-        void render_CRT(uint32_t* target, bool invert);
+        void memdump(uint32_t* target, uint16_t& width, uint16_t& height);
+        void render_CRT(uint32_t* target);
 
         void set_VBLANK(bool is_VBLANK);
         void assert_FINISH();

--- a/src/core/gsthread.hpp
+++ b/src/core/gsthread.hpp
@@ -191,7 +191,7 @@ class GraphicsSynthesizerThread
         //called from event loop
         void reset();
         void memdump();
-        void render_CRT(uint32_t* target);
+        void render_CRT(uint32_t* target, bool invert);
 
         void set_VBLANK(bool is_VBLANK);
         void assert_FINISH();

--- a/src/core/serialize.cpp
+++ b/src/core/serialize.cpp
@@ -14,8 +14,8 @@ bool Emulator::request_load_state(const char *file_name)
     if (!state.is_open())
         return false;
     state.close();
-    load_requested = true;
     savestate_path = file_name;
+    load_requested = true;
     return true;
 }
 
@@ -25,8 +25,8 @@ bool Emulator::request_save_state(const char *file_name)
     if (!state.is_open())
         return false;
     state.close();
-    save_requested = true;
     savestate_path = file_name;
+    save_requested = true;
     return true;
 }
 

--- a/src/qt/emuthread.cpp
+++ b/src/qt/emuthread.cpp
@@ -127,8 +127,11 @@ void EmuThread::gsdump_run()
                 }
                 case gsdump_t:
                     pause(PAUSE_EVENT::GAME_NOT_LOADED);
-                    printf("gsdump ended successfully\n");
-                    break;
+                    if (gsdump.peek() != EOF)
+                        Errors::die("gsdump ended before end of file!");
+                    gsdump.close();
+                    Errors::die("gsdump ended successfully\n");
+                    return;
                 case savestate_t:
                 case loadstate_t:
                     Errors::die("savestate save/load during gsdump not supported!");

--- a/src/qt/emuthread.cpp
+++ b/src/qt/emuthread.cpp
@@ -94,7 +94,7 @@ void EmuThread::gsdump_run()
     printf("gsdump frame\n");
     try
     {
-        int draws_sent = 100;
+        int draws_sent = 10;
         while (true)
         {
             GS_message data;

--- a/src/qt/emuthread.cpp
+++ b/src/qt/emuthread.cpp
@@ -89,6 +89,14 @@ void EmuThread::gsdump_write_toggle()
     e.request_gsdump_toggle();
     load_mutex.unlock();
 }
+
+void EmuThread::gsdump_single_frame()
+{
+    load_mutex.lock();
+    e.request_gsdump_single_frame();
+    load_mutex.unlock();
+}
+
 void EmuThread::gsdump_run()
 {
     printf("gsdump frame\n");

--- a/src/qt/emuthread.cpp
+++ b/src/qt/emuthread.cpp
@@ -94,7 +94,7 @@ void EmuThread::gsdump_run()
     printf("gsdump frame\n");
     try
     {
-        int draws_sent = 10;
+        int draws_sent = 100;
         while (true)
         {
             GS_message data;
@@ -105,15 +105,17 @@ void EmuThread::gsdump_run()
                     e.get_gs().send_message(data);
                     if (frame_advance && data.payload.xyz_payload.drawing_kick && --draws_sent <= 0)
                     {
-                        e.get_gs().render_partial_frame();
-                        goto render_partial_label;
+                        uint16_t w, h;
+                        uint32_t* frame = e.get_gs().render_partial_frame(w, h);
+                        emit completed_frame(frame, w, h, w, h);
+                        pause(PAUSE_EVENT::FRAME_ADVANCE);
+                        return;
                     }
                     break;
                 case render_crt_t:
                 {
                     printf("gsdump frame render\n");
                     e.get_gs().render_CRT();
-                render_partial_label:
                     int w, h, new_w, new_h;
                     e.get_inner_resolution(w, h);
                     e.get_resolution(new_w, new_h);

--- a/src/qt/emuthread.hpp
+++ b/src/qt/emuthread.hpp
@@ -13,7 +13,8 @@
 enum PAUSE_EVENT
 {
     GAME_NOT_LOADED,
-    FILE_DIALOG
+    FILE_DIALOG,
+    FRAME_ADVANCE,
 };
 
 class EmuThread : public QThread
@@ -26,6 +27,9 @@ class EmuThread : public QThread
         Emulator e;
 
         std::chrono::system_clock::time_point old_frametime;
+        std::ifstream gsdump;
+        std::atomic_bool gsdump_reading;
+        void gsdump_run();
     public:
         EmuThread();
 
@@ -38,6 +42,8 @@ class EmuThread : public QThread
 
         bool load_state(const char* name);
         bool save_state(const char* name);
+        bool gsdump_read(const char* name);
+        void gsdump_write_toggle();
     protected:
         void run() override;
     signals:

--- a/src/qt/emuthread.hpp
+++ b/src/qt/emuthread.hpp
@@ -44,6 +44,7 @@ class EmuThread : public QThread
         bool save_state(const char* name);
         bool gsdump_read(const char* name);
         void gsdump_write_toggle();
+        void gsdump_single_frame();
         bool frame_advance;
     protected:
         void run() override;

--- a/src/qt/emuthread.hpp
+++ b/src/qt/emuthread.hpp
@@ -44,6 +44,7 @@ class EmuThread : public QThread
         bool save_state(const char* name);
         bool gsdump_read(const char* name);
         void gsdump_write_toggle();
+        bool frame_advance;
     protected:
         void run() override;
     signals:

--- a/src/qt/emuwindow.cpp
+++ b/src/qt/emuwindow.cpp
@@ -314,6 +314,9 @@ void EmuWindow::keyPressEvent(QKeyEvent *event)
         case Qt::Key_Period:
             emuthread.unpause(PAUSE_EVENT::FRAME_ADVANCE);
             break;
+        case Qt::Key_F1:
+            emuthread.gsdump_single_frame();
+            break;
     }
 }
 

--- a/src/qt/emuwindow.cpp
+++ b/src/qt/emuwindow.cpp
@@ -69,7 +69,7 @@ int EmuWindow::init(int argc, char** argv)
     bool skip_BIOS = false;
     char* argv0; // Program name; AKA argv[0]
 
-    char* bios_name = nullptr, *file_name = nullptr;
+    char* bios_name = nullptr, *file_name = nullptr, *gsdump = nullptr;
 
     ARGBEGIN {
         case 'b':
@@ -81,6 +81,9 @@ int EmuWindow::init(int argc, char** argv)
         case 's':
             skip_BIOS = true;
             break;
+        case 'g':
+            gsdump = ARGF();
+            break;
         case 'h':
         default:
             printf("usage: %s [options]\n\n", argv0);
@@ -89,9 +92,14 @@ int EmuWindow::init(int argc, char** argv)
             printf("-f {ELF/ISO}\tspecify ELF/ISO\n");
             printf("-h\t\tshow this message\n");
             printf("-s\t\tskip BIOS\n");
+            printf("-g {.GSD}\t\trun a gsdump\n");
             return 1;
     } ARGEND
 
+    if (gsdump)
+    {
+        return run_gsdump(gsdump);
+    }
     ifstream BIOS_file(bios_name, ios::binary | ios::in);
     if (!BIOS_file.is_open())
     {
@@ -114,6 +122,12 @@ int EmuWindow::init(int argc, char** argv)
     return 0;
 }
 
+int EmuWindow::run_gsdump(const char* file_name)
+{
+    emuthread.gsdump_read(file_name);
+    emuthread.unpause(PAUSE_EVENT::GAME_NOT_LOADED);
+    return 0;
+}
 int EmuWindow::load_exec(const char* file_name, bool skip_BIOS)
 {
     ifstream exec_file(file_name, ios::binary | ios::in);
@@ -166,10 +180,10 @@ int EmuWindow::load_exec(const char* file_name, bool skip_BIOS)
 
 void EmuWindow::create_menu()
 {
-    load_rom_action = new QAction(tr("&Load ROM... (Fast)"), this);
+    load_rom_action = new QAction(tr("Load ROM... (&Fast)"), this);
     connect(load_rom_action, &QAction::triggered, this, &EmuWindow::open_file_skip);
 
-    load_bios_action = new QAction(tr("&Load ROM... (Boot BIOS)"), this);
+    load_bios_action = new QAction(tr("Load ROM... (&Boot BIOS)"), this);
     connect(load_bios_action, &QAction::triggered, this, &EmuWindow::open_file_no_skip);
 
     load_state_action = new QAction(tr("&Load State"), this);
@@ -181,12 +195,17 @@ void EmuWindow::create_menu()
     exit_action = new QAction(tr("&Exit"), this);
     connect(exit_action, &QAction::triggered, this, &QWidget::close);
 
+    auto gsdump_action = new QAction(tr("&GS dump toggle"), this);
+    connect(gsdump_action, &QAction::triggered, this,
+        [this]() { this->emuthread.gsdump_write_toggle(); });
+
     file_menu = menuBar()->addMenu(tr("&File"));
     file_menu->addAction(load_rom_action);
     file_menu->addAction(load_bios_action);
     file_menu->addAction(load_state_action);
     file_menu->addAction(save_state_action);
     file_menu->addAction(exit_action);
+    file_menu->addAction(gsdump_action);
 
     options_menu = menuBar()->addMenu(tr("&Options"));
     auto size_options_actions = new QAction(tr("Scale to &Window (ignore aspect ratio)"), this);
@@ -284,6 +303,9 @@ void EmuWindow::keyPressEvent(QKeyEvent *event)
             break;
         case Qt::Key_Space:
             emit press_key(PAD_BUTTON::SELECT);
+            break;
+        case Qt::Key_Period:
+            emuthread.unpause(PAUSE_EVENT::FRAME_ADVANCE);
             break;
     }
 }

--- a/src/qt/emuwindow.cpp
+++ b/src/qt/emuwindow.cpp
@@ -232,6 +232,13 @@ void EmuWindow::create_menu()
     connect(size_options_actions, &QAction::triggered, this,
         [this]() { this->scale_factor = 4; });
     options_menu->addAction(size_options_actions);
+
+    options_menu->addSeparator();
+
+    auto frame_action = new QAction(tr("&Frame Advance (10x draws for gs dumps)"), this);
+    connect(frame_action, &QAction::triggered, this,
+        [this]() { this->emuthread.frame_advance ^= true; });
+    options_menu->addAction(frame_action);
 }
 
 void EmuWindow::draw_frame(uint32_t *buffer, int inner_w, int inner_h, int final_w, int final_h)

--- a/src/qt/emuwindow.hpp
+++ b/src/qt/emuwindow.hpp
@@ -34,6 +34,7 @@ class EmuWindow : public QMainWindow
         explicit EmuWindow(QWidget *parent = nullptr);
         int init(int argc, char** argv);
         int load_exec(const char* file_name, bool skip_BIOS);
+        int run_gsdump(const char* file_name);
 
         void create_menu();
 


### PR DESCRIPTION
needs more testing
Record by using the toggle in the file menu. Saves to gsdump.gsd in working directory. Remember to toggle it off after you're done to prevent massive filesizes.
Load with -g <filename>. This will not load the BIOS, so the program must be closed once the gsdump is complete.

Frame advance is done with the period '.' key. Toggle in the options menu. gs dump by default is in frame advance mode, toggling it on will provide partial render output (this mode is not well-tested).