### PR TITLE
Sorta rewrote ADMA (again)

### DIFF
--- a/src/core/ee/cop0.cpp
+++ b/src/core/ee/cop0.cpp
@@ -156,12 +156,14 @@ void Cop0::count_up(int cycles)
     gpr[9] += cycles;
 
     //Performance counter registers
-    if (/*PCCR & (1 << 31)*/ true)
+    if (PCCR & (1 << 31))
     {
-        int event = (PCCR >> 5) & 0x1F;
+        int event0 = (PCCR >> 5) & 0x1F;
+        int event1 = (PCCR >> 15) & 0x1F;
 
-        bool can_count = false;
-        switch (event)
+        bool can_count0 = false;
+        bool can_count1 = false;
+        switch (event0)
         {
             case 1: //Processor cycle
             case 2: //Single/double instruction issue
@@ -170,14 +172,27 @@ void Cop0::count_up(int cycles)
             case 13: //Non-delay slot instruction completed
             case 14: //COP2/COP1 instruction completed
             case 15: //Load/store instruction completed
-                can_count = true;
+                can_count0 = true;
                 break;
         }
 
-        if (can_count)
+        switch (event1)
         {
-            PCR0 += cycles;
-            PCR1 += cycles;
+            case 1: //Processor cycle
+            case 2: //Single/double instruction issue
+            case 3: //Branch issued/mispredicted
+            case 12: //Instruction completed
+            case 13: //Non-delay slot instruction completed
+            case 14: //COP2/COP1 instruction completed
+            case 15: //Load/store instruction completed
+            can_count1 = true;
+            break;
         }
+
+        if (can_count0)
+            PCR0 += cycles;
+
+        if (can_count1)
+            PCR1 += cycles;
     }
 }

--- a/src/core/ee/dmac.cpp
+++ b/src/core/ee/dmac.cpp
@@ -1211,6 +1211,7 @@ void DMAC::write32(uint32_t address, uint32_t value)
             control.release_cycle = (value >> 8) & 0x7;
             break;
         case 0x1000E010:
+        case 0x1000E100:
             printf("[DMAC] Write32 D_STAT: $%08X\n", value);
             for (int i = 0; i < 15; i++)
             {

--- a/src/core/ee/dmac.cpp
+++ b/src/core/ee/dmac.cpp
@@ -671,8 +671,6 @@ void DMAC::handle_source_chain(int index)
 
 void DMAC::start_DMA(int index)
 {
-    if (channels[index].started)
-        return;
     printf("[DMAC] D%d started: $%08X\n", index, channels[index].control);
     int mode = (channels[index].control >> 2) & 0x3;
     channels[index].tag_end = !(mode & 0x1); //always end transfers in normal and interleave mode
@@ -883,16 +881,60 @@ void DMAC::write16(uint32_t address, uint16_t value)
     switch (address)
     {
         case 0x10008000:
-            channels[VIF0].control &= ~0xFFFF;
-            channels[VIF0].control |= value;
+            if (!(channels[VIF0].control & 0x100))
+            {
+                channels[VIF0].control &= ~0xFFFF;
+                channels[VIF0].control |= value;
+                if (value & 0x100)
+                    start_DMA(VIF0);
+                else
+                    channels[VIF0].started = false;
+            }
+            else
+            {
+                channels[VIF0].control &= (value & 0x100) | 0xFFFFFEFF;
+                channels[VIF0].started = (channels[VIF0].control & 0x100);
+            }
             break;
         case 0x10009000:
-            channels[VIF1].control &= ~0xFFFF;
-            channels[VIF1].control |= value;
+            if (!(channels[VIF1].control & 0x100))
+            {
+                channels[VIF1].control &= ~0xFFFF;
+                channels[VIF1].control |= value;
+                if (value & 0x100)
+                    start_DMA(VIF1);
+                else
+                    channels[VIF1].started = false;
+            }
+            else
+            {
+                channels[VIF1].control &= (value & 0x100) | 0xFFFFFEFF;
+                channels[VIF1].started = (channels[VIF1].control & 0x100);
+            }
             break;
         case 0x1000A000:
-            channels[GIF].control &= ~0xFFFF;
-            channels[GIF].control |= value;
+            if (!(channels[GIF].control & 0x100))
+            {
+                channels[GIF].control &= ~0xFFFF;
+                channels[GIF].control |= value;
+                if (value & 0x100)
+                {
+                    start_DMA(GIF);
+                    gif->request_PATH(3);
+                }
+                else
+                {
+                    channels[GIF].started = false;
+                    gif->deactivate_PATH(3);
+                }
+            }
+            else
+            {
+                channels[GIF].control &= (value & 0x100) | 0xFFFFFEFF;
+                channels[GIF].started = (channels[GIF].control & 0x100);
+                if(!channels[GIF].started)
+                    gif->deactivate_PATH(3);
+            }
             break;
         default:
             printf("[DMAC] Unrecognized write16 to $%08X of $%04X\n", address, value);
@@ -906,11 +948,19 @@ void DMAC::write32(uint32_t address, uint32_t value)
     {
         case 0x10008000:
             printf("[DMAC] VIF0 CTRL: $%08X\n", value);
-            channels[VIF0].control = value;
-            if (value & 0x100)
-                start_DMA(VIF0);
-            else if (master_disable & (1 << 16))
-                channels[VIF0].started = false;
+            if (!(channels[VIF0].control & 0x100))
+            {
+                channels[VIF0].control = value;
+                if (value & 0x100)
+                    start_DMA(VIF0);
+                else
+                    channels[VIF0].started = false;
+            }
+            else
+            {
+                channels[VIF0].control &= (value & 0x100) | 0xFFFFFEFF;
+                channels[VIF0].started = (channels[VIF0].control & 0x100);
+            }
             break;
         case 0x10008010:
             printf("[DMAC] VIF0 M_ADR: $%08X\n", value);
@@ -926,11 +976,19 @@ void DMAC::write32(uint32_t address, uint32_t value)
             break;
         case 0x10009000:
             printf("[DMAC] VIF1 CTRL: $%08X\n", value);
-            channels[VIF1].control = value;
-            if (value & 0x100)
-                start_DMA(VIF1);
-            else if (master_disable & (1 << 16))
-                channels[VIF1].started = false;
+            if (!(channels[VIF1].control & 0x100))
+            {
+                channels[VIF1].control = value;
+                if (value & 0x100)
+                    start_DMA(VIF1);
+                else
+                    channels[VIF1].started = false;
+            }
+            else
+            {
+                channels[VIF1].control &= (value & 0x100) | 0xFFFFFEFF;
+                channels[VIF1].started = (channels[VIF1].control & 0x100);
+            }
             break;
         case 0x10009010:
             printf("[DMAC] VIF1 M_ADR: $%08X\n", value);
@@ -946,15 +1004,24 @@ void DMAC::write32(uint32_t address, uint32_t value)
             break;
         case 0x1000A000:
             printf("[DMAC] GIF CTRL: $%08X\n", value);
-            channels[GIF].control = value;
-            if (value & 0x100)
+            if (!(channels[GIF].control & 0x100))
             {
-                start_DMA(GIF);
-                gif->request_PATH(3);
+                channels[GIF].control = value;
+                if (value & 0x100)
+                {
+                    start_DMA(GIF);
+                    gif->request_PATH(3);
+                }
+                else
+                {
+                    channels[GIF].started = false;
+                    gif->deactivate_PATH(3);
+                }
             }
-            else if (master_disable & (1 << 16))
+            else
             {
-                channels[GIF].started = false;
+                channels[GIF].control &= (value & 0x100) | 0xFFFFFEFF;
+                channels[GIF].started = (channels[GIF].control & 0x100);
                 gif->deactivate_PATH(3);
             }
             break;
@@ -972,11 +1039,19 @@ void DMAC::write32(uint32_t address, uint32_t value)
             break;
         case 0x1000B000:
             printf("[DMAC] IPU_FROM CTRL: $%08X\n", value);
-            channels[IPU_FROM].control = value;
-            if (value & 0x100)
-                start_DMA(IPU_FROM);
-            else if (master_disable & (1 << 16))
-                channels[IPU_FROM].started = false;
+            if (!(channels[IPU_FROM].control & 0x100))
+            {
+                channels[IPU_FROM].control = value;
+                if (value & 0x100)
+                    start_DMA(IPU_FROM);
+                else
+                    channels[IPU_FROM].started = false;
+            }
+            else
+            {
+                channels[IPU_FROM].control &= (value & 0x100) | 0xFFFFFEFF;
+                channels[IPU_FROM].started = (channels[IPU_FROM].control & 0x100);
+            }
             break;
         case 0x1000B010:
             printf("[DMAC] IPU_FROM M_ADR: $%08X\n", value);
@@ -988,11 +1063,19 @@ void DMAC::write32(uint32_t address, uint32_t value)
             break;
         case 0x1000B400:
             printf("[DMAC] IPU_TO CTRL: $%08X\n", value);
-            channels[IPU_TO].control = value;
-            if (value & 0x100)
-                start_DMA(IPU_TO);
-            else if (master_disable & (1 << 16))
-                channels[IPU_TO].started = false;
+            if (!(channels[IPU_TO].control & 0x100))
+            {
+                channels[IPU_TO].control = value;
+                if (value & 0x100)
+                    start_DMA(IPU_TO);
+                else
+                    channels[IPU_TO].started = false;
+            }
+            else
+            {
+                channels[IPU_TO].control &= (value & 0x100) | 0xFFFFFEFF;
+                channels[IPU_TO].started = (channels[IPU_TO].control & 0x100);
+            }
             break;
         case 0x1000B410:
             printf("[DMAC] IPU_TO M_ADR: $%08X\n", value);
@@ -1008,11 +1091,19 @@ void DMAC::write32(uint32_t address, uint32_t value)
             break;
         case 0x1000C000:
             printf("[DMAC] SIF0 CTRL: $%08X\n", value);
-            channels[SIF0].control = value;
-            if (value & 0x100)
-                start_DMA(SIF0);
-            else if (master_disable & (1 << 16))
-                channels[SIF0].started = false;
+            if (!(channels[SIF0].control & 0x100))
+            {
+                channels[SIF0].control = value;
+                if (value & 0x100)
+                    start_DMA(SIF0);
+                else
+                    channels[SIF0].started = false;
+            }
+            else
+            {
+                channels[SIF0].control &= (value & 0x100) | 0xFFFFFEFF;
+                channels[SIF0].started = (channels[SIF0].control & 0x100);
+            }
             break;
         case 0x1000C010:
             printf("[DMAC] SIF0 M_ADR: $%08X\n", value);
@@ -1024,11 +1115,19 @@ void DMAC::write32(uint32_t address, uint32_t value)
             break;
         case 0x1000C400:
             printf("[DMAC] SIF1 CTRL: $%08X\n", value);
-            channels[SIF1].control = value;
-            if (value & 0x100)
-                start_DMA(SIF1);
-            else if (master_disable & (1 << 16))
+            if (!(channels[SIF1].control & 0x100))
+            {
+                channels[SIF1].control = value;
+                if (value & 0x100)
+                    start_DMA(SIF1);
+                else
+                    channels[SIF1].started = false;
+            }
+            else
+            {
+                channels[SIF1].control &= (value & 0x100) | 0xFFFFFEFF;
                 channels[SIF1].started = false;
+            }
             break;
         case 0x1000C410:
             printf("[DMAC] SIF1 M_ADR: $%08X\n", value);
@@ -1044,11 +1143,19 @@ void DMAC::write32(uint32_t address, uint32_t value)
             break;
         case 0x1000D000:
             printf("[DMAC] SPR_FROM CTRL: $%08X\n", value);
-            channels[SPR_FROM].control = value;
-            if (value & 0x100)
-                start_DMA(SPR_FROM);
-            else if (master_disable & (1 << 16))
-                channels[SPR_FROM].started = false;
+            if (!(channels[SPR_FROM].control & 0x100))
+            {
+                channels[SPR_FROM].control = value;
+                if (value & 0x100)
+                    start_DMA(SPR_FROM);
+                else
+                    channels[SPR_FROM].started = false;
+            }
+            else
+            {
+                channels[SPR_FROM].control &= (value & 0x100) | 0xFFFFFEFF;
+                channels[SPR_FROM].started = (channels[SPR_FROM].control & 0x100);
+            }
             break;
         case 0x1000D010:
             printf("[DMAC] SPR_FROM M_ADR: $%08X\n", value);
@@ -1064,11 +1171,19 @@ void DMAC::write32(uint32_t address, uint32_t value)
             break;
         case 0x1000D400:
             printf("[DMAC] SPR_TO CTRL: $%08X\n", value);
-            channels[SPR_TO].control = value;
-            if (value & 0x100)
-                start_DMA(SPR_TO);
-            else if (master_disable & (1 << 16))
-                channels[SPR_TO].started = false;
+            if (!(channels[SPR_TO].control & 0x100))
+            {
+                channels[SPR_TO].control = value;
+                if (value & 0x100)
+                    start_DMA(SPR_TO);
+                else
+                    channels[SPR_TO].started = false;
+            }
+            else
+            {
+                channels[SPR_TO].control &= (value & 0x100) | 0xFFFFFEFF;
+                channels[SPR_TO].started = (channels[SPR_TO].control & 0x100);
+            }
             break;
         case 0x1000D410:
             printf("[DMAC] SPR_TO M_ADR: $%08X\n", value);

--- a/src/core/ee/dmac.cpp
+++ b/src/core/ee/dmac.cpp
@@ -920,7 +920,7 @@ void DMAC::write16(uint32_t address, uint16_t value)
                 if (value & 0x100)
                 {
                     start_DMA(GIF);
-                    gif->request_PATH(3);
+                    gif->request_PATH(3, false);
                 }
                 else
                 {
@@ -1010,7 +1010,7 @@ void DMAC::write32(uint32_t address, uint32_t value)
                 if (value & 0x100)
                 {
                     start_DMA(GIF);
-                    gif->request_PATH(3);
+                    gif->request_PATH(3, false);
                 }
                 else
                 {

--- a/src/core/ee/dmac.cpp
+++ b/src/core/ee/dmac.cpp
@@ -1126,7 +1126,7 @@ void DMAC::write32(uint32_t address, uint32_t value)
             else
             {
                 channels[SIF1].control &= (value & 0x100) | 0xFFFFFEFF;
-                channels[SIF1].started = false;
+                channels[SIF1].started = (channels[SIF1].control & 0x100);
             }
             break;
         case 0x1000C410:

--- a/src/core/ee/emotiondisasm.cpp
+++ b/src/core/ee/emotiondisasm.cpp
@@ -1185,7 +1185,7 @@ string EmotionDisasm::disasm_cop_bc1(uint32_t instruction, uint32_t instr_addr)
 
     stringstream output;
     string opcode = "";
-    const static char* ops[] = {"bc1f", "bc1fl", "bc1t", "bc1tl"};
+    const static char* ops[] = {"bc1f", "bc1t", "bc1fl", "bc1tl"};
     int32_t offset = IMM << 2;
     uint8_t op = RT;
     if (op > 3)

--- a/src/core/ee/vif.hpp
+++ b/src/core/ee/vif.hpp
@@ -58,6 +58,7 @@ class VectorInterface
         bool vif_stop;
         
         bool wait_for_VU;
+        bool wait_for_PATH3;
         bool flush_stall;
         uint32_t wait_cmd_value;
 

--- a/src/core/ee/vu.cpp
+++ b/src/core/ee/vu.cpp
@@ -167,7 +167,7 @@ void VectorUnit::run(int cycles)
         cycles_to_run--;
     }
 
-    if (id == 1)
+    if (id == 1 && transferring_GIF)
     {
         if (gif->path_active(1))
         {
@@ -765,6 +765,21 @@ void VectorUnit::eexp(uint32_t instr)
         value += coeffs[exp - 1] * pow(x, exp);
 
     P.f = 1.0 / value;
+}
+
+void VectorUnit::ercpr(uint32_t instr)
+{
+    if (!id)
+    {
+        Errors::die("[VU] ERCPR called on VU0!\n");
+    }
+
+    P.f = convert(gpr[_fs_].u[_fsf_]);
+
+    if (P.f != 0)
+        P.f = 1.0f / P.f;
+
+    printf("[VU] ERCPR: %f (%d)\n", P.f, _fs_);
 }
 
 void VectorUnit::eleng(uint32_t instr)
@@ -2242,7 +2257,7 @@ void VectorUnit::xgkick(uint32_t instr)
     else
     {
         XGKICK_cycles = 0;
-        gif->request_PATH(1);
+        gif->request_PATH(1, true);
         transferring_GIF = true;
         GIF_addr = (uint32_t)(int_gpr[_is_].u & 0x3ff) * 16;
     }

--- a/src/core/ee/vu.hpp
+++ b/src/core/ee/vu.hpp
@@ -166,6 +166,7 @@ class VectorUnit
         void clip(uint32_t instr);
         void div(uint32_t instr);
         void eexp(uint32_t instr);
+        void ercpr(uint32_t instr);
         void eleng(uint32_t instr);
         void esqrt(uint32_t instr);
         void erleng(uint32_t instr);

--- a/src/core/ee/vu_disasm.cpp
+++ b/src/core/ee/vu_disasm.cpp
@@ -462,6 +462,8 @@ string VU_Disasm::lower1_special(uint32_t PC, uint32_t instr)
             return esqrt(instr);
         case 0x79:
             return ersqrt(instr);
+        case 0x7A:
+            return ercpr(instr);
         case 0x7B:
             return "waitp";
         case 0x7E:
@@ -689,6 +691,14 @@ string VU_Disasm::eleng(uint32_t instr)
     stringstream output;
     uint32_t source = (instr >> 11) & 0x1F;
     output << "eleng P, vf" << source;
+    return output.str();
+}
+
+string VU_Disasm::ercpr(uint32_t instr)
+{
+    stringstream output;
+    uint32_t source = (instr >> 11) & 0x1F;
+    output << "ercpr P, vf" << source << "." << get_fsf((instr >> 21) & 0x3);
     return output.str();
 }
 

--- a/src/core/ee/vu_disasm.hpp
+++ b/src/core/ee/vu_disasm.hpp
@@ -54,6 +54,7 @@ namespace VU_Disasm
     std::string xitop(uint32_t instr);
     std::string xgkick(uint32_t instr);
     std::string eleng(uint32_t instr);
+    std::string ercpr(uint32_t instr);
     std::string erleng(uint32_t instr);
     std::string esqrt(uint32_t instr);
     std::string ersqrt(uint32_t instr);

--- a/src/core/ee/vu_interpreter.cpp
+++ b/src/core/ee/vu_interpreter.cpp
@@ -1272,6 +1272,9 @@ void lower1_special(VectorUnit &vu, uint32_t instr)
         case 0x79:
             ersqrt(vu, instr);
             break;
+        case 0x7A:
+            ercpr(vu, instr);
+            break;
         case 0x7B:
             //waitp should always execute before upper
             vu.waitp(instr);
@@ -1504,6 +1507,16 @@ void xgkick(VectorUnit &vu, uint32_t instr)
 {
     uint8_t is = (instr >> 11) & 0x1F;
     lower_op = &VectorUnit::xgkick;
+}
+
+void ercpr(VectorUnit &vu, uint32_t instr)
+{
+    uint8_t source = (instr >> 11) & 0x1F;
+    uint8_t fsf = (instr >> 21) & 0x3;
+
+    vu.decoder.vf_read0[1] = source;
+    vu.decoder.vf_read0_field[1] = 1 << (3 - fsf);
+    lower_op = &VectorUnit::ercpr;
 }
 
 void eleng(VectorUnit &vu, uint32_t instr)

--- a/src/core/ee/vu_interpreter.hpp
+++ b/src/core/ee/vu_interpreter.hpp
@@ -99,6 +99,7 @@ namespace VU_Interpreter
     void xitop(VectorUnit& vu, uint32_t instr);
     void xgkick(VectorUnit& vu, uint32_t instr);
     void eleng(VectorUnit& vu, uint32_t instr);
+    void ercpr(VectorUnit& vu, uint32_t instr);
     void erleng(VectorUnit& vu, uint32_t instr);
     void esqrt(VectorUnit& vu, uint32_t instr);
     void ersqrt(VectorUnit& vu, uint32_t instr);

--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -644,6 +644,9 @@ void Emulator::write32(uint32_t address, uint32_t value)
         case 0x10002010:
             ipu.write_control(value);
             return;
+        case 0x10003010:
+            gif.write_MODE(value);
+            return;
         case 0x10003C10:
             vif1.set_fbrst(value);
             return;

--- a/src/core/iop/iop_dma.cpp
+++ b/src/core/iop/iop_dma.cpp
@@ -130,13 +130,8 @@ void IOP_DMA::process_SPU()
             //Transfer 512 bytes of data (128 words) at once
             spu->write_ADMA(RAM + channels[SPU].addr);
             //printf("[IOP DMA] SPU transfer: $%08X\n", channels[SPU].size * 2);
-            if (!spu->running_ADMA())
-            {
-                transfer_end(SPU);
-                spu->finish_DMA();
-            }
-            channels[SPU].size -= (0x40 / 2);
-            channels[SPU].addr += 0x80;
+            channels[SPU].size--;
+            channels[SPU].addr += 4;
         }
     }
     else
@@ -165,13 +160,8 @@ void IOP_DMA::process_SPU2()
         {
             //Transfer 512 bytes of data (128 words) at once
             spu2->write_ADMA(RAM + channels[SPU2].addr);
-            channels[SPU2].size -= (0x40 / 2);
-            channels[SPU2].addr += 0x80;
-            if (!spu2->running_ADMA())
-            {
-                transfer_end(SPU2);
-                spu2->finish_DMA();
-            }
+            channels[SPU2].size--;
+            channels[SPU2].addr += 4;
         }
     }
     else

--- a/src/core/iop/spu.cpp
+++ b/src/core/iop/spu.cpp
@@ -10,8 +10,6 @@
  * Bit 2 seems to be some sort of finish flag?
  */
 
-uint16_t SPU::autodma_ctrl = 0;
-
 SPU::SPU(int id, Emulator* e) : id(id), e(e)
 { 
 
@@ -27,7 +25,6 @@ void SPU::reset(uint8_t* RAM)
     core_att = 0;
     autodma_ctrl = 0x0;
     ADMA_left = 0;
-    can_write_adma = false;
     input_pos = 0;
 
     spdif_irq = 0;
@@ -117,20 +114,23 @@ void SPU::gen_sample()
             }
         }
     }
-    input_pos++;
-    if (ADMA_left >= 0x40 && !can_write_adma && autodma_ctrl & (1 << (id - 1)))
-        can_write_adma = true;
-    input_pos &= 0x1FF;
+
+    if (ADMA_left > 0 && autodma_ctrl & (1 << (id - 1)))
+    {
+        input_pos++;
+        process_ADMA();
+        input_pos &= 0x1FF;
+    }
 }
 
 bool SPU::running_ADMA()
 {
-    return ADMA_left > 0;
+    return (autodma_ctrl & (1 << (id - 1)));
 }
 
 bool SPU::can_write_ADMA()
 {
-    return can_write_adma;
+    return (input_pos <= 128 || input_pos >= 384) && (ADMA_left < 0x400);
 }
 
 void SPU::finish_DMA()
@@ -144,11 +144,7 @@ void SPU::start_DMA(int size)
     if (autodma_ctrl & (1 << (id - 1)))
     {
         printf("ADMA started with size: $%08X\n", size);
-        ADMA_left = size;
-        can_write_adma = false;
     }
-    else
-        ADMA_left = -1;
     status.DMA_finished = false;
 }
 
@@ -165,14 +161,24 @@ void SPU::write_DMA(uint32_t value)
 
 void SPU::write_ADMA(uint8_t *RAM)
 {
-    //printf("[SPU%d] ADMA transfer: $%08X\n", id, ADMA_left);
-    can_write_adma = false;
-    ADMA_left -= 0x40;
-    if (ADMA_left < 0x40)
+   // printf("[SPU%d] ADMA transfer: $%08X\n", id, ADMA_left);
+    ADMA_left += 2;
+    status.DMA_busy = true;
+    status.DMA_finished = false;
+}
+
+void SPU::process_ADMA() 
+{
+    if (input_pos == 128 || input_pos == 384)
     {
-        printf("[SPU%d] ADMA finished!\n", id);
-        autodma_ctrl |= ~3;
-        ADMA_left = 0;
+        ADMA_left -= std::min(ADMA_left, 0x200);
+
+        if (ADMA_left < 0x200)
+        {
+            autodma_ctrl |= 0x4;
+        }
+        else
+            autodma_ctrl &= ~0x4;
     }
 }
 
@@ -380,6 +386,10 @@ void SPU::write16(uint32_t addr, uint16_t value)
             break;
         case 0x342:
             ENDX &= 0xFFFF;
+            break;
+        case 0x5B0:
+            printf("[SPU%d] Write ADMA: $%04X\n", id, value);
+            autodma_ctrl = value;
             break;
         default:
             printf("[SPU%d] Unrecognized write16 to addr $%08X of $%04X\n", id, addr, value);

--- a/src/core/iop/spu.cpp
+++ b/src/core/iop/spu.cpp
@@ -387,10 +387,6 @@ void SPU::write16(uint32_t addr, uint16_t value)
         case 0x342:
             ENDX &= 0xFFFF;
             break;
-        case 0x5B0:
-            printf("[SPU%d] Write ADMA: $%04X\n", id, value);
-            autodma_ctrl = value;
-            break;
         default:
             printf("[SPU%d] Unrecognized write16 to addr $%08X of $%04X\n", id, addr, value);
     }

--- a/src/core/iop/spu.hpp
+++ b/src/core/iop/spu.hpp
@@ -42,9 +42,8 @@ class SPU
         uint32_t current_addr;
 
         //ADMA bullshit
-        static uint16_t autodma_ctrl;
+        uint16_t autodma_ctrl;
         int ADMA_left;
-        bool can_write_adma;
         int input_pos;
 
         int cycles;
@@ -74,6 +73,7 @@ class SPU
         void finish_DMA();
 
         uint16_t read_mem();
+        void process_ADMA();
         void write_DMA(uint32_t value);
         void write_ADMA(uint8_t* RAM);
         void write_mem(uint16_t value);

--- a/src/core/serialize.cpp
+++ b/src/core/serialize.cpp
@@ -4,7 +4,7 @@
 
 #define VER_MAJOR 0
 #define VER_MINOR 0
-#define VER_REV 7
+#define VER_REV 8
 
 using namespace std;
 
@@ -479,7 +479,7 @@ void IOP_DMA::save_state(ofstream &state)
 
 void GraphicsInterface::load_state(ifstream &state)
 {
-    state.read((char*)&current_tag, sizeof(current_tag));
+    state.read((char*)&path, sizeof(path));
     state.read((char*)&active_path, sizeof(active_path));
     state.read((char*)&path_queue, sizeof(path_queue));
     state.read((char*)&path3_vif_masked, sizeof(path3_vif_masked));
@@ -487,7 +487,7 @@ void GraphicsInterface::load_state(ifstream &state)
 
 void GraphicsInterface::save_state(ofstream &state)
 {
-    state.write((char*)&current_tag, sizeof(current_tag));
+    state.write((char*)&path, sizeof(path));
     state.write((char*)&active_path, sizeof(active_path));
     state.write((char*)&path_queue, sizeof(path_queue));
     state.write((char*)&path3_vif_masked, sizeof(path3_vif_masked));


### PR DESCRIPTION
Split ADMA from the DMA channels
ADMA has a control register per core now
Adjusted the timings for ADMA

Fixed EE DMA Resuming

Implemented PATH3 Masking
Implemented ERCPR VU Instruction
Split GIF Paths to handle Intermittent mode
Split the PCCR count events correctly
Fixed Disassembly printout for bc1 instructions
Removed some redundant VIF code