### PR TITLE
PATH3 Masking fixes when PATH3 has finished but VIF doesn't know yet

### DIFF
--- a/src/core/ee/vif.cpp
+++ b/src/core/ee/vif.cpp
@@ -31,7 +31,7 @@ void VectorInterface::reset()
     vu->set_GIF(gif);
     wait_for_VU = false;
     wait_for_PATH3 = false;
-    vif_stalled = false;
+    vif_stalled = 0;
     vif_ibit_detected = false;
     vif_interrupt = false;
     vif_stop = false;
@@ -51,7 +51,7 @@ bool VectorInterface::check_vif_stall(uint32_t value)
 
             //Do not stall if the command is MARK
             if (((value >> 24) & 0x7f) != 0x7)
-                vif_stalled = true;
+                vif_stalled |= 0x1;
 
             if (get_id())
                 intc->assert_IRQ((int)Interrupt::VIF1);
@@ -61,7 +61,7 @@ bool VectorInterface::check_vif_stall(uint32_t value)
         }
         if (vif_stop)
         {
-            vif_stalled = true;
+            vif_stalled |= 0x1;
             return true;
         }
     }
@@ -74,6 +74,12 @@ void VectorInterface::update(int cycles)
     //This allows us to process one quadword per bus cycle
     int runcycles = cycles << 2;
    
+    if (vif_stalled & 0x2)
+    {
+        gif->resume_path3();
+        vif_stalled &= ~0x2;
+    }
+
     while (!vif_stalled && runcycles--)
     {        
         if (wait_for_VU)
@@ -230,7 +236,7 @@ void VectorInterface::decode_cmd(uint32_t value)
             printf("[VIF] MSKPATH3: %d\n", (value >> 15) & 0x1);
             gif->set_path3_vifmask((value >> 15) & 0x1);
             command = 0;
-            gif->resume_path3();
+            vif_stalled |= 0x2;
             break;
         case 0x07:
             printf("[VIF] Set MARK: $%08X\n", value);
@@ -909,12 +915,12 @@ void VectorInterface::disasm_micromem()
 uint32_t VectorInterface::get_stat()
 {
     uint32_t reg = 0;
-    reg |= vif_stalled ? 0 : ((FIFO.size() != 0) * 3);
+    reg |= (vif_stalled & 0x1) ? 0 : ((FIFO.size() != 0) * 3);
     reg |= vu->is_running() << 2;
     reg |= mark_detected << 6;
     reg |= DBF << 7;
     reg |= vif_stop << 8;
-    reg |= vif_stalled << 10;
+    reg |= (vif_stalled & 0x1) << 10;
     reg |= vif_interrupt << 11;
     reg |= ((FIFO.size() + 3) / 4) << 24;
     //printf("[VIF] Get STAT: $%08X\n", reg);
@@ -974,7 +980,7 @@ void VectorInterface::set_fbrst(uint32_t value)
     if (value & 0x8)
     {
         printf("[VIF] VIF%x Resumed\n", get_id());
-        vif_stalled = false;
+        vif_stalled &= ~0x1;
         vif_interrupt = false;
         vif_stop = false;
     }

--- a/src/core/ee/vif.hpp
+++ b/src/core/ee/vif.hpp
@@ -11,6 +11,12 @@
 
 class GraphicsInterface;
 
+enum VIF_STALL
+{
+    STALL_IBIT = 1,
+    STALL_MSKPATH3 = 2
+};
+
 struct MPG_Command
 {
     uint32_t addr;

--- a/src/core/ee/vif.hpp
+++ b/src/core/ee/vif.hpp
@@ -53,7 +53,7 @@ class VectorInterface
         UNPACK_Command unpack;
 
         bool vif_ibit_detected;
-        bool vif_stalled;
+        uint8_t vif_stalled;
         bool vif_interrupt;
         bool vif_stop;
         

--- a/src/core/gif.hpp
+++ b/src/core/gif.hpp
@@ -90,10 +90,13 @@ inline bool GraphicsInterface::path_activepath3(int index)
 
 inline void GraphicsInterface::resume_path3()
 {
-    if (path3_vif_masked)
+    if (path3_vif_masked || path3_mode_masked)
         return;
-    if (active_path == 3 || (path_queue & (1 << 3)))
+    if (active_path == 3 || (path_queue & (1 << 3)) && path_status[3] == 4)
+    {
+        //printf("[GIF] Resuming PATH3\n");
         path_status[3] = 0; //Force it to be busy so if VIF puts the mask back on quickly, it doesn't instantly mask it
+    }
 }
 
 #endif // GIF_HPP


### PR DESCRIPTION
Fixed bug where FINISH wouldn't be called if the last packet of GIF data was NLOOP 0 EOP 1