### PR TITLE
Keep track of the bios path / slightly better checking on loading bios

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ set(SOURCES
 	src/qt/emuthread.cpp
         src/qt/emuwindow.cpp
         src/qt/main.cpp
+	src/qt/settings.cpp
         )
 
 set(HEADERS
@@ -121,6 +122,7 @@ set(HEADERS
 	src/core/sif.hpp
 	src/qt/emuthread.hpp
         src/qt/emuwindow.hpp
+	src/qt/settings.hpp
         )
 
 add_executable(DobieStation ${SOURCES} ${HEADERS})

--- a/src/qt/emuwindow.cpp
+++ b/src/qt/emuwindow.cpp
@@ -109,17 +109,19 @@ int EmuWindow::init(int argc, char** argv)
     {
         return run_gsdump(gsdump);
     }
+
     ifstream BIOS_file(bios_name, ios::binary | ios::in);
-    if (!BIOS_file.is_open())
+    if (!BIOS_file.is_open() || (filesize(bios_name) == 0))
     {
         printf("Failed to load PS2 BIOS from %s\n", bios_name);
         return 1;
     }
-    printf("Loaded PS2 BIOS.\n");
+    
     uint8_t* BIOS = new uint8_t[1024 * 1024 * 4];
     BIOS_file.read((char*)BIOS, 1024 * 1024 * 4);
     BIOS_file.close();
     emuthread.load_BIOS(BIOS);
+    printf("Loaded PS2 BIOS.\n");
     delete[] BIOS;
     BIOS = nullptr;
 

--- a/src/qt/emuwindow.cpp
+++ b/src/qt/emuwindow.cpp
@@ -84,7 +84,7 @@ int EmuWindow::init(int argc, char** argv)
         case 'b':
             bios_name = ARGF();
 
-            // Save the bios path in settings, converting to a QString along the way.
+            // Store the bios path, converting to a QString along the way.
             Settings::bios_path = QString::fromLocal8Bit(bios_name);
             break;
         case 'f':

--- a/src/qt/emuwindow.cpp
+++ b/src/qt/emuwindow.cpp
@@ -2,6 +2,7 @@
 #include <fstream>
 #include <iostream>
 
+#include <QApplication>
 #include <QPainter>
 #include <QString>
 #include <QVBoxLayout>
@@ -14,6 +15,7 @@
 #include "arg.h"
 
 using namespace std;
+char* bios_name = nullptr;
 
 ifstream::pos_type filesize(const char* filename)
 {
@@ -73,7 +75,10 @@ int EmuWindow::init(int argc, char** argv)
     bool skip_BIOS = false;
     char* argv0; // Program name; AKA argv[0]
 
-    char* bios_name = nullptr, *file_name = nullptr, *gsdump = nullptr;
+    char *file_name = nullptr, *gsdump = nullptr;
+
+    // Load before the arguments, so the arguments override the config.
+    load_settings();
 
     ARGBEGIN {
         case 'b':
@@ -117,6 +122,9 @@ int EmuWindow::init(int argc, char** argv)
     emuthread.load_BIOS(BIOS);
     delete[] BIOS;
     BIOS = nullptr;
+
+    // Save at the end of init, so our arguments are saved.
+    save_settings();
 
     if (file_name)
     {
@@ -209,6 +217,7 @@ void EmuWindow::create_menu()
     file_menu->addAction(load_state_action);
     file_menu->addAction(save_state_action);
     file_menu->addAction(exit_action);
+    file_menu->addSeparator();
     file_menu->addAction(gsdump_action);
 
     options_menu = menuBar()->addMenu(tr("&Options"));

--- a/src/qt/emuwindow.hpp
+++ b/src/qt/emuwindow.hpp
@@ -7,6 +7,7 @@
 
 #include "emuthread.hpp"
 
+#include "../qt/settings.hpp"
 #include "../core/emulator.hpp"
 
 class EmuWindow : public QMainWindow

--- a/src/qt/settings.cpp
+++ b/src/qt/settings.cpp
@@ -1,0 +1,31 @@
+#include <QSettings>
+#include <QString>
+
+#include "settings.hpp"
+
+extern char* bios_name;
+
+// https://wiki.qt.io/Technical_FAQ#How_can_I_convert_a_QString_to_char.2A_and_vice_versa.3F
+bool load_settings()
+{
+    QSettings settings("PSI", "Dobiestation");
+    QString q_bios = settings.value("bios", "").toString();
+    QByteArray ba = q_bios.toLocal8Bit();
+
+    bios_name = ba.data();
+
+    printf("Loaded config! Bios: %s\n", bios_name);
+}
+
+bool save_settings()
+{
+    // Note: bizarrely, bios_name seems to get totally erased when initializing settings. 
+    // Grab a copy first thing.
+    QString q_bios = QString::fromLocal8Bit(bios_name);
+    QSettings settings("PSI", "Dobiestation");
+
+    settings.setValue("bios", q_bios);
+    settings.sync();
+
+    printf("Saved config! Bios: %s\n", qPrintable(q_bios));
+}

--- a/src/qt/settings.cpp
+++ b/src/qt/settings.cpp
@@ -9,7 +9,7 @@ namespace Settings
 
     // If we had a files for QT helper functions, this could go there, but here works for now.
     // https://wiki.qt.io/Technical_FAQ#How_can_I_convert_a_QString_to_char.2A_and_vice_versa.3F
-    char *as_char(QString q_str)
+    char* as_char(QString q_str)
     {
         QByteArray ba = q_str.toLocal8Bit();
         return ba.data();

--- a/src/qt/settings.cpp
+++ b/src/qt/settings.cpp
@@ -3,29 +3,33 @@
 
 #include "settings.hpp"
 
-extern char* bios_name;
-
-// https://wiki.qt.io/Technical_FAQ#How_can_I_convert_a_QString_to_char.2A_and_vice_versa.3F
-bool load_settings()
+namespace Settings
 {
-    QSettings settings("PSI", "Dobiestation");
-    QString q_bios = settings.value("bios", "").toString();
-    QByteArray ba = q_bios.toLocal8Bit();
+    QString bios_path;
 
-    bios_name = ba.data();
+    // If we had a files for QT helper functions, this could go there, but here works for now.
+    // https://wiki.qt.io/Technical_FAQ#How_can_I_convert_a_QString_to_char.2A_and_vice_versa.3F
+    char *as_char(QString q_str)
+    {
+        QByteArray ba = q_str.toLocal8Bit();
+        return ba.data();
+    }
 
-    printf("Loaded config! Bios: %s\n", bios_name);
-}
+    bool load()
+    {
+        QSettings conf("PSI", "Dobiestation");
 
-bool save_settings()
-{
-    // Note: bizarrely, bios_name seems to get totally erased when initializing settings. 
-    // Grab a copy first thing.
-    QString q_bios = QString::fromLocal8Bit(bios_name);
-    QSettings settings("PSI", "Dobiestation");
+        bios_path = conf.value("bios", "").toString();
+        printf("Loaded config! Bios: %s\n", qPrintable(bios_path));
+    }
 
-    settings.setValue("bios", q_bios);
-    settings.sync();
+    bool save()
+    {
+        QSettings conf("PSI", "Dobiestation");
 
-    printf("Saved config! Bios: %s\n", qPrintable(q_bios));
-}
+        conf.setValue("bios", bios_path);
+        conf.sync();
+
+        printf("Saved config! Bios: %s\n", qPrintable(bios_path));
+    }
+};

--- a/src/qt/settings.hpp
+++ b/src/qt/settings.hpp
@@ -1,0 +1,9 @@
+#ifndef SETTINGS_H
+#define SETTINGS_H
+
+#include <QString>
+
+extern bool load_settings();
+extern bool save_settings();
+
+#endif

--- a/src/qt/settings.hpp
+++ b/src/qt/settings.hpp
@@ -7,7 +7,7 @@ namespace Settings
 {
     extern QString bios_path;
 
-    extern char *as_char(QString q_str);
+    extern char* as_char(QString q_str);
     extern bool load();
     extern bool save();
 };

--- a/src/qt/settings.hpp
+++ b/src/qt/settings.hpp
@@ -3,7 +3,13 @@
 
 #include <QString>
 
-extern bool load_settings();
-extern bool save_settings();
+namespace Settings
+{
+    extern QString bios_path;
+
+    extern char *as_char(QString q_str);
+    extern bool load();
+    extern bool save();
+};
 
 #endif


### PR DESCRIPTION
I tried to keep things a bit simple on this one.

I added functions to load and save the current app settings using Qt with the Native way of saving them for that platform. (See https://doc.qt.io/qt-5/qsettings.html).

It loads the bios path from settings, then immediately writes over it if the bios was passed as an argument. It then saves the current bios path after the bios is loaded. I also added a check in there because it would happily take a directory for the bios path, load up, then not load anything.

In theory, making an option dialog and letting you choose the path would be a good idea, as well as setting where your elf/isos are, what scale to load up with, being able to turn on and off logs for part of the emulator, etc... but I figure that's all exercises for the future. ^_^