### PR TITLE
Handle PSMCT8 in local_to_local()

### DIFF
--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -2252,6 +2252,10 @@ void GraphicsSynthesizerThread::local_to_local()
                 data = read_PSMCT32_block(BITBLTBUF.source_base, BITBLTBUF.source_width,
                                           TRXPOS.int_source_x, TRXPOS.int_source_y);
                 break;
+            case 0x13:
+                data = read_PSMCT8_block(BITBLTBUF.source_base, BITBLTBUF.source_width,
+                                         TRXPOS.int_source_x, TRXPOS.int_source_y);
+                break;
             case 0x14:
                 data = read_PSMCT4_block(BITBLTBUF.source_base, BITBLTBUF.source_width,
                                          TRXPOS.int_source_x, TRXPOS.int_source_y);
@@ -2268,6 +2272,10 @@ void GraphicsSynthesizerThread::local_to_local()
                 break;
             case 0x01:
                 write_PSMCT24_block(BITBLTBUF.dest_base, BITBLTBUF.dest_width,
+                                    TRXPOS.int_dest_x, TRXPOS.int_dest_y, data);
+                break;
+            case 0x13:
+                write_PSMCT8_block(BITBLTBUF.dest_base, BITBLTBUF.dest_width,
                                     TRXPOS.int_dest_x, TRXPOS.int_dest_y, data);
                 break;
             case 0x14:


### PR DESCRIPTION
Fixes regressions in level-5 games