### PR TITLE
Fix cmake

### DIFF
--- a/src/core/ee/ipu/vlc_table.hpp
+++ b/src/core/ee/ipu/vlc_table.hpp
@@ -1,5 +1,6 @@
 #ifndef VLC_TABLE_HPP
 #define VLC_TABLE_HPP
+#include <stdexcept>
 #include <cstdint>
 #include <queue>
 #include "ipu_fifo.hpp"


### PR DESCRIPTION
Adding this include allows cmake to run properly on Linux.
Tested by kojin to make sure this doesn't break Windows build.

Tested machine is laptop running Ubuntu MATE 18.10