### PR TITLE
Vu int hazard

### DIFF
--- a/src/core/ee/vu.cpp
+++ b/src/core/ee/vu.cpp
@@ -890,11 +890,9 @@ void VectorUnit::ctc(int index, uint32_t value)
 
 void VectorUnit::branch(bool condition, int16_t imm, bool link, uint8_t linkreg)
 {
+    int_branch_pipeline.flush();
     if (condition)
     {
-        // on taken conditional branch, flush the integer branch pipeline
-        // NOTE: we do NOT flush the integer load pipeline!
-        int_branch_pipeline.flush();
         if (branch_on)
         {
             second_branch_pending = true;
@@ -915,6 +913,7 @@ void VectorUnit::branch(bool condition, int16_t imm, bool link, uint8_t linkreg)
 
 void VectorUnit::jp(uint16_t addr, bool link, uint8_t linkreg)
 {
+    int_branch_pipeline.flush();
     if (branch_on)
     {
         second_branch_pending = true;

--- a/src/core/ee/vu.cpp
+++ b/src/core/ee/vu.cpp
@@ -1,7 +1,6 @@
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
-#include <cassert>
 #include "vu.hpp"
 #include "vu_interpreter.hpp"
 #include "vu_jit.hpp"
@@ -596,17 +595,6 @@ void VectorUnit::start_EFU_unit(int latency)
 {
     finish_EFU_event = cycle_count + latency;
     EFU_event_started = true;
-}
-
-void VectorUnit::set_int_branch_delay(uint8_t reg)
-{
-    assert(false);
-    if (reg)
-    {
-        int_branch_delay = 2;
-        int_backup_id = reg;
-        int_backup_reg = int_gpr[reg].u;
-    }
 }
 
 void VectorUnit::write_int(uint8_t reg, uint8_t read0, uint8_t read1)

--- a/src/core/ee/vu.cpp
+++ b/src/core/ee/vu.cpp
@@ -774,7 +774,7 @@ VU_I VectorUnit::read_int_for_branch_condition(uint8_t reg)
     VU_I value = int_gpr[reg];
     if(reg)
     {
-        int_branch_pipeline.get_branch_condition_reg(reg, value, id, PC);
+        value = int_branch_pipeline.get_branch_condition_reg(reg, value, id, PC);
     }
     return value;
 }

--- a/src/core/ee/vu.hpp
+++ b/src/core/ee/vu.hpp
@@ -78,9 +78,7 @@ struct VuIntBranchPipeline
     // completely reset pipeline to VU power on state
     void reset()
     {
-//        last_op_read_write = false;
-//        current_op_read_write = false;
-//        next.clear();
+        next.clear();
         flush();
     }
 
@@ -98,7 +96,6 @@ struct VuIntBranchPipeline
         pipeline[0] = next;
         for(int i = 0; i < length - 1; i++)
             pipeline[i+1] = pipeline[i];
-
 
         next.clear();
     }

--- a/src/core/ee/vu.hpp
+++ b/src/core/ee/vu.hpp
@@ -69,7 +69,7 @@ struct VuIntBranchPipeline
     static constexpr int length = 5;           // how far back to go behind the branch
     VuIntBranchPipelineEntry pipeline[length]; // the previous integer operations (0 is most recent)
     VuIntBranchPipelineEntry next;             // the currently executing integer op
-    
+
     void reset();
     void write_reg(uint8_t reg, VU_I old_value, bool also_read);
     void update();

--- a/src/core/ee/vu.hpp
+++ b/src/core/ee/vu.hpp
@@ -224,7 +224,6 @@ class VectorUnit
         void start_DIV_unit(int latency);
         //Updates new_P_Instance
         void start_EFU_unit(int latency);
-        void set_int_branch_delay(uint8_t reg);
         void write_int(uint8_t reg, uint8_t read0 = 0, uint8_t readq1 = 0);
         VU_I read_int_for_branch_condition(uint8_t reg);
         

--- a/src/core/ee/vu_interpreter.cpp
+++ b/src/core/ee/vu_interpreter.cpp
@@ -5,6 +5,17 @@
 
 #define printf(fmt, ...)(0)
 
+#define _ft_ ((instr >> 16) & 0x1F)
+#define _fs_ ((instr >> 11) & 0x1F)
+#define _fd_ ((instr >> 6) & 0x1F)
+
+#define _field ((instr >> 21) & 0xF)
+
+#define _it_ (_ft_ & 0xF)
+#define _is_ (_fs_ & 0xF)
+#define _id_ (_fd_ & 0xF)
+
+
 namespace VU_Interpreter
 {
 typedef void(VectorUnit::*vu_op)(uint32_t);
@@ -53,6 +64,7 @@ void interpret(VectorUnit &vu, uint32_t upper_instr, uint32_t lower_instr)
     if (!(upper_instr & (1 << 31)))
         lower(vu, lower_instr);
 
+    // check for stalls before execution
     vu.check_for_FMAC_stall();
     
     //LOI - upper op always executes first
@@ -1200,6 +1212,9 @@ void iadd(VectorUnit &vu, uint32_t instr)
     uint8_t reg1 = (instr >> 11) & 0x1F;
     uint8_t reg2 = (instr >> 16) & 0x1F;*/
     vu.decoder.vi_write = (instr >> 6) & 0xF;
+    vu.decoder.vi_read0 = _is_;
+    vu.decoder.vi_read1 = _it_;
+
     lower_op = &VectorUnit::iadd;
 }
 
@@ -1209,6 +1224,8 @@ void isub(VectorUnit &vu, uint32_t instr)
     uint8_t reg1 = (instr >> 11) & 0x1F;
     uint8_t reg2 = (instr >> 16) & 0x1F;*/
     vu.decoder.vi_write = (instr >> 6) & 0xF;
+    vu.decoder.vi_read0 = _is_;
+    vu.decoder.vi_read1 = _it_;
     lower_op = &VectorUnit::isub;
 }
 
@@ -1219,6 +1236,7 @@ void iaddi(VectorUnit &vu, uint32_t instr)
     uint8_t source = (instr >> 11) & 0x1F;
     uint8_t dest = (instr >> 16) & 0x1F;*/
     vu.decoder.vi_write = (instr >> 16) & 0xF;
+    vu.decoder.vi_read0 = _is_;
     lower_op = &VectorUnit::iaddi;
 }
 
@@ -1228,6 +1246,9 @@ void iand(VectorUnit &vu, uint32_t instr)
     uint8_t reg1 = (instr >> 11) & 0x1F;
     uint8_t reg2 = (instr >> 16) & 0x1F;*/
     vu.decoder.vi_write = (instr >> 6) & 0xF;
+    vu.decoder.vi_read0 = _is_;
+    vu.decoder.vi_read1 = _it_;
+
     lower_op = &VectorUnit::iand;
 }
 
@@ -1237,6 +1258,8 @@ void ior(VectorUnit &vu, uint32_t instr)
     uint8_t reg1 = (instr >> 11) & 0x1F;
     uint8_t reg2 = (instr >> 16) & 0x1F;*/
     vu.decoder.vi_write = (instr >> 6) & 0xF;
+    vu.decoder.vi_read0 = _is_;
+    vu.decoder.vi_read1 = _it_;
     lower_op = &VectorUnit::ior;
 }
 
@@ -1387,6 +1410,7 @@ void lqi(VectorUnit &vu, uint32_t instr)
     vu.decoder.vf_write[1] = ft;
     vu.decoder.vf_write_field[1] = field;
     vu.decoder.vi_write = is;
+    vu.decoder.vi_read0 = _is_;
     lower_op = &VectorUnit::lqi;
 }
 
@@ -1398,6 +1422,7 @@ void sqi(VectorUnit& vu, uint32_t instr)
     vu.decoder.vf_read0[1] = fs;
     vu.decoder.vf_read0_field[1] = dest_field;
     vu.decoder.vi_write = it;
+    vu.decoder.vi_read0 = _it_;
     lower_op = &VectorUnit::sqi;
 }
 
@@ -1409,6 +1434,7 @@ void lqd(VectorUnit &vu, uint32_t instr)
     vu.decoder.vf_write[1] = ft;
     vu.decoder.vf_write_field[1] = dest_field;
     vu.decoder.vi_write = is;
+    vu.decoder.vi_read0 = _is_;
     lower_op = &VectorUnit::lqd;
 }
 
@@ -1420,6 +1446,7 @@ void sqd(VectorUnit &vu, uint32_t instr)
     vu.decoder.vf_read0[1] = fs;
     vu.decoder.vf_read0_field[1] = dest_field;
     vu.decoder.vi_write = it;
+    vu.decoder.vi_read0 = _it_;
     lower_op = &VectorUnit::sqd;
 }
 
@@ -1489,6 +1516,7 @@ void mfir(VectorUnit &vu, uint32_t instr)
     vu.decoder.vi_read0 = is;
     vu.decoder.vf_write[1] = ft;
     vu.decoder.vf_write_field[1] = dest_field;
+    vu.decoder.vi_read0 = _is_;
     lower_op = &VectorUnit::mfir;
 }
 
@@ -1498,6 +1526,9 @@ void ilwr(VectorUnit &vu, uint32_t instr)
     uint8_t it = (instr >> 16) & 0x1F;
     uint8_t field = (instr >> 21) & 0xF;*/
     vu.decoder.vi_write = (instr >> 16) & 0xF;
+    vu.decoder.vi_write_from_load = _it_;
+    vu.decoder.vi_read0 = _is_;
+
     lower_op = &VectorUnit::ilwr;
 }
 
@@ -1506,6 +1537,9 @@ void iswr(VectorUnit &vu, uint32_t instr)
     /*uint8_t is = (instr >> 11) & 0x1F;
     uint8_t it = (instr >> 16) & 0x1F;
     uint8_t field = (instr >> 21) & 0xF;*/
+    vu.decoder.vi_read0 = _is_;
+    vu.decoder.vi_read1 = _it_;
+
     lower_op = &VectorUnit::iswr;
 }
 
@@ -1576,6 +1610,7 @@ void xitop(VectorUnit &vu, uint32_t instr)
 void xgkick(VectorUnit &vu, uint32_t instr)
 {
     uint8_t is = (instr >> 11) & 0x1F;
+    vu.decoder.vi_read0 = _is_;
     lower_op = &VectorUnit::xgkick;
 }
 
@@ -1768,6 +1803,7 @@ void lq(VectorUnit &vu, uint32_t instr)
     uint8_t ft = (instr >> 16) & 0x1F;
     uint8_t field = (instr >> 21) & 0xF;
 
+    vu.decoder.vi_read0 = _is_;
     vu.decoder.vf_write[1] = ft;
     vu.decoder.vf_write_field[1] = field;
     lower_op = &VectorUnit::lq;
@@ -1779,6 +1815,7 @@ void sq(VectorUnit &vu, uint32_t instr)
     uint8_t it = (instr >> 16) & 0x1F;
     uint8_t field = (instr >> 21) & 0xF;
 
+    vu.decoder.vi_read0 = _it_;
     vu.decoder.vf_read0[1] = fs;
     vu.decoder.vf_read0_field[1] = field;
     lower_op = &VectorUnit::sq;
@@ -1793,6 +1830,9 @@ void ilw(VectorUnit &vu, uint32_t instr)
     uint8_t it = (instr >> 16) & 0x1F;
     uint8_t field = (instr >> 21) & 0xF;*/
     vu.decoder.vi_write = (instr >> 16) & 0xF;
+    vu.decoder.vi_write_from_load = _it_;
+    vu.decoder.vi_read0 = _is_;
+
     lower_op = &VectorUnit::ilw;
 }
 
@@ -1804,6 +1844,9 @@ void isw(VectorUnit &vu, uint32_t instr)
     uint8_t is = (instr >> 11) & 0x1F;
     uint8_t it = (instr >> 16) & 0x1F;
     uint8_t field = (instr >> 21) & 0xF;*/
+    vu.decoder.vi_read0 = _is_;
+    vu.decoder.vi_read1 = _it_;
+
     lower_op = &VectorUnit::isw;
 }
 
@@ -1814,6 +1857,7 @@ void iaddiu(VectorUnit &vu, uint32_t instr)
     uint8_t source = (instr >> 11) & 0x1F;
     uint8_t dest = (instr >> 16) & 0x1F;*/
     vu.decoder.vi_write = (instr >> 16) & 0xF;
+    vu.decoder.vi_read0 = _is_;
     lower_op = &VectorUnit::iaddiu;
 }
 
@@ -1824,6 +1868,7 @@ void isubiu(VectorUnit &vu, uint32_t instr)
     uint8_t source = (instr >> 11) & 0x1F;
     uint8_t dest = (instr >> 16) & 0x1F;*/
     vu.decoder.vi_write = (instr >> 16) & 0xF;
+    vu.decoder.vi_read0 = _is_;
     lower_op = &VectorUnit::isubiu;
 }
 
@@ -1859,16 +1904,19 @@ void fsand(VectorUnit &vu, uint32_t instr)
 
 void fmeq(VectorUnit &vu, uint32_t instr)
 {
+    vu.decoder.vi_read0 = _is_;
     lower_op = &VectorUnit::fmeq;
 }
 
 void fmand(VectorUnit &vu, uint32_t instr)
 {
+    vu.decoder.vi_read0 = _is_;
     lower_op = &VectorUnit::fmand;
 }
 
 void fmor(VectorUnit &vu, uint32_t instr)
 {
+    vu.decoder.vi_read0 = _is_;
     lower_op = &VectorUnit::fmor;
 }
 

--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -91,8 +91,8 @@ void Emulator::run()
         vif1.update(cycles);
         gif.run(cycles);
         vu0.run(cycles);
-        //vu1.run(cycles);
-        vu1.run_jit(cycles);
+        vu1.run(cycles);
+        //vu1.run_jit(cycles);
         cycles >>= 2;
         iop_timers.run(cycles);
         iop_dma.run(cycles);

--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -91,8 +91,8 @@ void Emulator::run()
         vif1.update(cycles);
         gif.run(cycles);
         vu0.run(cycles);
-        vu1.run(cycles);
-        //vu1.run_jit(cycles);
+        //vu1.run(cycles);
+        vu1.run_jit(cycles);
         cycles >>= 2;
         iop_timers.run(cycles);
         iop_dma.run(cycles);


### PR DESCRIPTION


Load Stalls, to fix issues with this:
```
[$3c40] 000002ff:5007104a nop                           ibeq vi7, vi2, $3e98
[$3c48] 000002ff:082f0084 nop                           ilw.w vi15, 0x0084(vi0) 

Branch target $3e98:
[$3e98] 000002ff:52007804 nop                           ibne vi0, vi15, $3ec0 ;; should get vi15 from the ilw.w
```

Weird branch behavior, to fix issues with this:
```
;; value of vi8 from here should be used in the branch
[$14d0] 01ee7c2c:81e88b7d sub.xyzw vf16, vf15, vf14     sqi.xyzw vf17, (vi8++) 
[$14d8] 01f194ec:81e8a37d sub.xyzw vf19, vf18, vf17     sqi.xyzw vf20, (vi8++)
[$14e0] 01f4adac:81e8737d sub.xyzw vf22, vf21, vf20     sqi.xyzw vf14, (vi8++)
[$14e8] 000002ff:50074752 nop                           ibeq vi7, vi8, $0f80
```

So far this has only been tested with Jak (which still doesn't work, but seems to be closer), so I might have broken other games.

This also fixes a flag issue in RSQRT, and makes lqi/ldq/sqi/sqd work with the integer branch pipeline.

Currently JALR/JR won't do integer load stalls on the register they read.
Also, the link register set by JALR won't be used as part of the integer branch pipeline (it can be used immediately).