### PR TITLE
Add screenshot functionality

### DIFF
--- a/src/qt/emuwindow.cpp
+++ b/src/qt/emuwindow.cpp
@@ -372,6 +372,12 @@ void EmuWindow::create_menu()
 
         window_menu->addAction(scale_action);
     }
+
+    auto screenshot_action = new QAction(tr("&Take Screenshot"), this);
+    connect(screenshot_action, &QAction::triggered, render_widget, &RenderWidget::screenshot);
+
+    window_menu->addSeparator();
+    window_menu->addAction(screenshot_action);
 }
 
 bool EmuWindow::load_bios()
@@ -462,6 +468,9 @@ void EmuWindow::keyPressEvent(QKeyEvent *event)
             break;
         case Qt::Key_F1:
             emu_thread.gsdump_single_frame();
+            break;
+        case Qt::Key_F8:
+            render_widget->screenshot();
             break;
     }
 }

--- a/src/qt/renderwidget.cpp
+++ b/src/qt/renderwidget.cpp
@@ -1,6 +1,10 @@
 #include <QPainter>
+#include <QImageWriter>
+#include <QDateTime>
+#include <QDebug>
 
 #include "renderwidget.hpp"
+#include "settings.hpp"
 
 RenderWidget::RenderWidget(QWidget* parent)
     : QWidget(parent)
@@ -55,4 +59,29 @@ void RenderWidget::toggle_aspect_ratio()
 bool RenderWidget::get_respect_aspect_ratio() const
 {
     return respect_aspect_ratio;
+}
+
+void RenderWidget::screenshot()
+{
+    QString file_name(
+        QDateTime::currentDateTime()
+            .toString("yyyyMMddHHmmsszzz")
+            .append(".png")
+    );
+
+    QString directory(Settings::instance().screenshot_directory);
+
+    QString output_file(
+        directory.append(QDir::separator()).append(file_name)
+    );
+
+    QImageWriter writer(output_file, "png");
+
+    if (!writer.canWrite())
+    {
+        qDebug() << "Could not take screenshot!";
+        return;
+    }
+
+    writer.write(final_image);
 }

--- a/src/qt/renderwidget.hpp
+++ b/src/qt/renderwidget.hpp
@@ -22,5 +22,6 @@ class RenderWidget : public QWidget
     public slots:
         void draw_frame(uint32_t* buffer, int inner_w, int inner_h, int final_w, int final_h);
         void toggle_aspect_ratio();
+        void screenshot();
 };
 #endif

--- a/src/qt/settings.cpp
+++ b/src/qt/settings.cpp
@@ -31,6 +31,7 @@ void Settings::reset()
     recent_roms = qsettings().value("recent_roms", {}).toStringList();
     vu1_jit_enabled = qsettings().value("vu1_jit_enabled", true).toBool();
     last_used_directory = qsettings().value("last_used_dir", QDir::homePath()).toString();
+    screenshot_directory = qsettings().value("screenshot_directory", QDir::homePath()).toString();
 
     rom_directories_to_add = QStringList();
     rom_directories_to_remove = QStringList();
@@ -63,6 +64,7 @@ void Settings::save()
     qsettings().setValue("rom_directories", rom_directories);
     qsettings().setValue("bios_path", bios_path);
     qsettings().setValue("vu1_jit_enabled", vu1_jit_enabled);
+    qsettings().setValue("screenshot_directory", screenshot_directory);
     qsettings().sync();
     reset();
 }
@@ -79,13 +81,13 @@ QSettings& Settings::qsettings()
     return settings;
 }
 
-void Settings::update_last_used_directory(QString path)
+void Settings::update_last_used_directory(const QString& path)
 {
     last_used_directory = path;
     qsettings().setValue("last_used_dir", last_used_directory);
 }
 
-void Settings::add_rom_directory(QString path)
+void Settings::add_rom_directory(const QString& path)
 {
     if (path.isEmpty())
         return;
@@ -96,7 +98,7 @@ void Settings::add_rom_directory(QString path)
     }
 }
 
-void Settings::remove_rom_directory(QString path)
+void Settings::remove_rom_directory(const QString& path)
 {
     if (path.isEmpty())
         return;
@@ -107,7 +109,7 @@ void Settings::remove_rom_directory(QString path)
     }
 }
 
-void Settings::add_rom_path(QString path)
+void Settings::add_rom_path(const QString& path)
 {
     if (path.isEmpty())
         return;
@@ -126,11 +128,20 @@ void Settings::clear_rom_paths()
     qsettings().setValue("recent_roms", {});
 }
 
-void Settings::set_bios_path(QString path)
+void Settings::set_bios_path(const QString& path)
 {
     if (path.isEmpty())
         return;
 
     bios_path = path;
     emit bios_changed(path);
+}
+
+void Settings::set_screenshot_directory(const QString& directory)
+{
+    if (directory.isEmpty())
+        return;
+
+    screenshot_directory = directory;
+    emit screenshot_directory_changed(directory);
 }

--- a/src/qt/settings.hpp
+++ b/src/qt/settings.hpp
@@ -22,6 +22,7 @@ class Settings final : public QObject
 
         QString bios_path;
         QString last_used_directory;
+        QString screenshot_directory;
         QStringList rom_directories;
         QStringList rom_directories_to_add;
         QStringList rom_directories_to_remove;
@@ -31,12 +32,13 @@ class Settings final : public QObject
 
         void save();
         void reset();
-        void update_last_used_directory(QString path);
-        void add_rom_directory(QString directory);
-        void add_rom_path(QString path);
-        void set_bios_path(QString path);
+        void update_last_used_directory(const QString& path);
+        void add_rom_directory(const QString& directory);
+        void add_rom_path(const QString& path);
+        void set_bios_path(const QString& path);
+        void set_screenshot_directory(const QString& directory);
 
-        void remove_rom_directory(QString directory);
+        void remove_rom_directory(const QString& directory);
         void clear_rom_paths();
     private:
         Settings();
@@ -47,6 +49,7 @@ class Settings final : public QObject
         void rom_directory_committed(const QString& directory);
         void rom_directory_uncommitted(const QString& directory);
         void bios_changed(const QString& path);
+        void screenshot_directory_changed(const QString& directory);
         void reload();
 };
 #endif

--- a/src/qt/settingswindow.cpp
+++ b/src/qt/settingswindow.cpp
@@ -114,7 +114,7 @@ PathTab::PathTab(QWidget* parent)
     edit_layout->addLayout(button_layout);
 
     QPushButton* browse_button = new QPushButton(tr("Browse"));
-    connect(browse_button, &QAbstractButton::clicked, this, [=]() {
+    connect(browse_button, &QAbstractButton::clicked, [=]() {
         QString path = QFileDialog::getOpenFileName(
             this, tr("Open Bios"), Settings::instance().last_used_directory,
             tr("Bios File (*.bin)")
@@ -126,22 +126,43 @@ PathTab::PathTab(QWidget* parent)
     BiosReader bios_reader(Settings::instance().bios_path);
     bios_info = new QLabel(bios_reader.to_string());
 
-    QGridLayout* bios_layout = new QGridLayout;
-    bios_layout->addWidget(bios_info, 0, 0);
-    bios_layout->addWidget(browse_button, 0, 3);
+    QPushButton* screenshot_button = new QPushButton(tr("Browse"));
+    connect(screenshot_button, &QAbstractButton::clicked, [=]() {
+        QString directory = QFileDialog::getExistingDirectory(
+            this, tr("Choose Screenshot Directory"),
+            Settings::instance().last_used_directory
+        );
 
-    bios_layout->setColumnStretch(1, 1);
-    bios_layout->setAlignment(Qt::AlignTop);
+        Settings::instance().set_screenshot_directory(directory);
+    });
+
+    auto screenshot_label =
+        new QLabel(Settings::instance().screenshot_directory);
+
+    connect(&Settings::instance(), &Settings::screenshot_directory_changed, [=](QString directory) {
+        screenshot_label->setText(directory);
+    });
+
+    QGridLayout* other_layout = new QGridLayout;
+    other_layout->addWidget(new QLabel(tr("Bios:"), 0, 0));
+    other_layout->addWidget(bios_info, 0, 2);
+    other_layout->addWidget(browse_button, 0, 3);
+    other_layout->addWidget(new QLabel("Screenshots:"), 1, 0);
+    other_layout->addWidget(screenshot_label, 1, 2);
+    other_layout->addWidget(screenshot_button, 1, 3);
+
+    other_layout->setColumnStretch(1, 1);
+    other_layout->setAlignment(Qt::AlignTop);
 
     QGroupBox* path_groupbox = new QGroupBox(tr("Rom Directories"));
     path_groupbox->setLayout(edit_layout);
 
-    QGroupBox* bios_groupbox = new QGroupBox(tr("Bios"));
-    bios_groupbox->setLayout(bios_layout);
+    QGroupBox* other_groupbox = new QGroupBox(tr("Other"));
+    other_groupbox->setLayout(other_layout);
 
     QVBoxLayout* layout = new QVBoxLayout;
     layout->addWidget(path_groupbox);
-    layout->addWidget(bios_groupbox);
+    layout->addWidget(other_groupbox);
 
     setLayout(layout);
 }


### PR DESCRIPTION
Add the ability to take screenshots 2 ways:
- By pressing `f8`
- `Window -> Take Screenshot`

The directory in which screenshots are saved can be changed by the user `Options -> Settings -> Paths -> Screenshots`. When it's not set, it's the user's home directory.

The format of the screenshot filename is as follows:
`yyyyMMddHHmmsszzz.png`.

Currently uses default settings for compression.
PNG used because JPEG is garbage.