### PR TITLE
Implement IOP read32 0x1F808410

### DIFF
--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -1183,6 +1183,8 @@ uint32_t Emulator::iop_read32(uint32_t address)
             return sio2.get_RECV2();
         case 0x1F808274:
             return sio2.get_RECV3();
+        case 0x1F808410:
+            return 8; // Some sort of FireWire thing
         case 0xFFFE0130: //Cache control?
             return 0;
     }


### PR DESCRIPTION
This allows Gran Turismo 3 to boot past the copyright screen.
Reading this address will return 8, which is theorized to indicate that FireWire is ready.

(Now gets stuck attempting to go in game "[IPU] Error - command sent while busy!")