### PR TITLE
VU_JIT: Pass the correct PC at the start of a program

### DIFF
--- a/src/core/ee/vu.cpp
+++ b/src/core/ee/vu.cpp
@@ -749,8 +749,6 @@ void VectorUnit::start_program(uint32_t addr)
     uint32_t new_addr = addr & mem_mask;
     printf("[VU%d] CallMS Starting execution at $%08X! Cur PC %x\n", get_id(), new_addr, PC);
 
-    disasm_micromem();
-
     //Enable this if disabling micromem disasm
     /*if (get_id() == 1 && is_dirty())
     {
@@ -773,6 +771,7 @@ void VectorUnit::start_program(uint32_t addr)
         }
         flush_pipes();
     }
+    disasm_micromem();
     run_event = cycle_count;
 }
 

--- a/src/core/ee/vu_jit64.cpp
+++ b/src/core/ee/vu_jit64.cpp
@@ -2223,6 +2223,7 @@ void VU_JIT64::xgkick(VectorUnit &vu, IR::Instruction &instr)
         emitter.load_addr((uint64_t)&prev_pc, REG_64::RAX);
         emitter.MOV32_IMM_MEM(instr.get_source(), REG_64::RAX);
 
+        //Flush entire pipeline on stall, it's not accurate but probably the best we can assume (and better than not)
         REG_64 q_reg = alloc_sse_reg(vu, VU_SpecialReg::Q, REG_STATE::WRITE);
         emitter.load_addr((uint64_t)&vu.new_Q_instance, REG_64::RAX);
         emitter.MOVAPS_FROM_MEM(REG_64::RAX, q_reg);

--- a/src/core/ee/vu_jit64.cpp
+++ b/src/core/ee/vu_jit64.cpp
@@ -2223,6 +2223,29 @@ void VU_JIT64::xgkick(VectorUnit &vu, IR::Instruction &instr)
         emitter.load_addr((uint64_t)&prev_pc, REG_64::RAX);
         emitter.MOV32_IMM_MEM(instr.get_source(), REG_64::RAX);
 
+        REG_64 q_reg = alloc_sse_reg(vu, VU_SpecialReg::Q, REG_STATE::WRITE);
+        emitter.load_addr((uint64_t)&vu.new_Q_instance, REG_64::RAX);
+        emitter.MOVAPS_FROM_MEM(REG_64::RAX, q_reg);
+        set_clamping(q_reg, true, 0xF);
+       
+        emitter.load_addr((uint64_t)&vu.pipeline_state[0], REG_64::RAX);
+        emitter.MOV64_OI(0, REG_64::R15);
+        emitter.MOV64_TO_MEM(REG_64::R15, REG_64::RAX);
+
+        emitter.load_addr((uint64_t)&vu.pipeline_state[1], REG_64::RAX);
+        emitter.MOV64_OI(instr.get_source2(), REG_64::R15);
+        emitter.MOV64_TO_MEM(REG_64::R15, REG_64::RAX);
+
+        //Store the pipelined P inside the P available to the program
+        REG_64 p_reg = alloc_sse_reg(vu, VU_SpecialReg::P, REG_STATE::WRITE);
+        emitter.load_addr((uint64_t)&vu.new_P_instance, REG_64::RAX);
+        emitter.MOVAPS_FROM_MEM(REG_64::RAX, p_reg);
+        set_clamping(p_reg, true, 0xF);
+        
+        prepare_abi(vu, (uint64_t)&vu);
+        prepare_abi(vu, 4);
+        call_abi_func((uint64_t)vu_update_pipelines);
+
         cleanup_recompiler(vu, false);
     }
 


### PR DESCRIPTION
-Store branch/ebit state in VU state
-Flush pipes on XGKick stall (assume it's going to take longer than the cycles needed for now)
-Flush mac pipe on program end

