### PR TITLE
Switch VU Jit to multiprogram mode

### DIFF
--- a/src/core/ee/vu_jit64.cpp
+++ b/src/core/ee/vu_jit64.cpp
@@ -178,7 +178,7 @@ void VU_JIT64::reset(bool clear_cache)
 
 void VU_JIT64::set_current_program(uint32_t crc)
 {
-    reset(current_program != crc);
+    reset(false);
     current_program = crc;
 
 }


### PR DESCRIPTION
This allows the JIT to run without tossing away recompiled blocks when switching programs.