### PR TITLE
Rework GS threading

### DIFF
--- a/src/core/gs.cpp
+++ b/src/core/gs.cpp
@@ -5,9 +5,7 @@
 #include <fstream>
 #include "ee/intc.hpp"
 #include "gs.hpp"
-#include "gsthread.hpp"
 #include "errors.hpp"
-using namespace std;
 
 /**
 This is a manager for the gsthread. It deals with communication
@@ -15,61 +13,35 @@ in/out of the GS, mostly with the GIF but also with the privileged
 registers.
 **/
 
-GraphicsSynthesizer::GraphicsSynthesizer(INTC* intc) : intc(intc)
+GraphicsSynthesizer::GraphicsSynthesizer(INTC* intc) 
+    : intc(intc), frame_complete(false),
+    output_buffer1(nullptr), output_buffer2(nullptr)
 {
-    frame_complete = false;
-    output_buffer1 = nullptr;
-    output_buffer2 = nullptr;
-    message_queue = nullptr;
-    return_queue = nullptr;
-    gsthread_id = std::thread();//no thread/default constructor
 }
 
 GraphicsSynthesizer::~GraphicsSynthesizer()
 {
-    if (gsthread_id.joinable())
-    {
-        GSMessagePayload payload;
-        payload.no_payload = {0};
-        send_message({ GSCommand::die_t,payload });
-        gsthread_id.join();
-    }
+    gs_thread.exit();
+
     delete[] output_buffer1;
     delete[] output_buffer2;
-    delete message_queue;
-    delete return_queue;
 }
 
 void GraphicsSynthesizer::reset()
 {
     if (!output_buffer1)
         output_buffer1 = new uint32_t[1920 * 1280];
+
     if (!output_buffer2)
         output_buffer2 = new uint32_t[1920 * 1280];
-    if (!message_queue)
-        message_queue = new gs_fifo();
-    if (!return_queue)
-        return_queue = new gs_return_fifo();
+
     current_lock = std::unique_lock<std::mutex>();
     using_first_buffer = true;
     frame_count = 0;
     set_CRT(false, 0x2, false);
     reg.reset();
-    if (gsthread_id.joinable())
-    {
-        GSMessagePayload payload;
-        payload.no_payload = {0};
-        send_message({ GSCommand::die_t,payload });
-        gsthread_id.join();
-    }
-    {
-        GSReturnMessage data;
-        while (return_queue->pop(data));
 
-        GSMessage data2;
-        while (message_queue->pop(data2));
-    }
-    gsthread_id = std::thread(&GraphicsSynthesizerThread::event_loop, message_queue, return_queue);//pass references to the fifos
+    gs_thread.reset_fifos();
 }
 
 void GraphicsSynthesizer::start_frame()
@@ -77,7 +49,7 @@ void GraphicsSynthesizer::start_frame()
     frame_complete = false;
 }
 
-bool GraphicsSynthesizer::is_frame_complete()
+bool GraphicsSynthesizer::is_frame_complete() const
 {
     return frame_complete;
 }
@@ -88,41 +60,17 @@ void GraphicsSynthesizer::set_CRT(bool interlaced, int mode, bool frame_mode)
 
     GSMessagePayload payload;
     payload.crt_payload = { interlaced, mode, frame_mode };
-    send_message({ GSCommand::set_crt_t,payload });
-}
 
-void wait_for_return(gs_return_fifo *return_queue, GSReturn type, GSReturnMessage &data)
-{
-    printf("wait for return\n");
-    while (true)
-    {
-        if (return_queue->pop(data))
-        {
-            if (data.type == death_error_t)
-            {
-                auto p = data.payload.death_error_payload;
-                auto data = std::string(p.error_str);
-                delete[] p.error_str;
-                Errors::die(data.c_str());
-                //There's probably a better way of doing this
-                //but I don't know how to make RAII work across threads properly
-            }
-
-            if (data.type == type)
-                return;
-            else
-                Errors::die("[GS] return message expected %d but was %d!\n", type, data.type);
-        }
-        else
-            std::this_thread::yield();
-    }
+    gs_thread.send_message({ GSCommand::set_crt_t, payload });
 }
 
 uint32_t* GraphicsSynthesizer::get_framebuffer()
 {
     uint32_t* out;
     GSReturnMessage data;
-    wait_for_return(return_queue, GSReturn::render_complete_t, data);
+
+    gs_thread.wait_for_return(GSReturn::render_complete_t, data);
+    
     if (using_first_buffer)
     {
         while (!output_buffer1_mutex.try_lock())
@@ -151,7 +99,8 @@ void GraphicsSynthesizer::set_VBLANK(bool is_VBLANK)
 {
     GSMessagePayload payload;
     payload.vblank_payload = { is_VBLANK };
-    send_message({ GSCommand::set_vblank_t,payload });
+    
+    gs_thread.send_message({ GSCommand::set_vblank_t, payload });
 
     reg.set_VBLANK(is_VBLANK);
 
@@ -174,7 +123,8 @@ void GraphicsSynthesizer::assert_VSYNC()
 {
     GSMessagePayload payload;
     payload.no_payload = {};
-    message_queue->push({ GSCommand::assert_vsync_t,payload });
+    
+    gs_thread.send_message({ GSCommand::assert_vsync_t, payload });
 
     if (reg.assert_VSYNC())
         intc->assert_IRQ((int)Interrupt::GS);
@@ -184,7 +134,8 @@ void GraphicsSynthesizer::assert_FINISH()
 {
     GSMessagePayload payload;
     payload.no_payload = { };
-    send_message({ GSCommand::assert_finish_t,payload });
+    
+    gs_thread.send_message({ GSCommand::assert_finish_t, payload });
 
     if (reg.assert_FINISH())
         intc->assert_IRQ((int)Interrupt::GS);
@@ -193,24 +144,29 @@ void GraphicsSynthesizer::assert_FINISH()
 void GraphicsSynthesizer::render_CRT()
 {
     GSMessagePayload payload;
+
     if (using_first_buffer)
         payload.render_payload = { output_buffer1, &output_buffer1_mutex };
     else
         payload.render_payload = { output_buffer2, &output_buffer2_mutex }; ;
-    send_message({ GSCommand::render_crt_t,payload });
+    
+    gs_thread.send_message({ GSCommand::render_crt_t, payload });
 }
 
 uint32_t* GraphicsSynthesizer::render_partial_frame(uint16_t& width, uint16_t& height)
 {
     GSMessagePayload payload;
+
     if (using_first_buffer)
         payload.render_payload = { output_buffer1, &output_buffer1_mutex };
     else
         payload.render_payload = { output_buffer2, &output_buffer2_mutex }; ;
-    send_message({ GSCommand::memdump_t,payload });
+    
+    gs_thread.send_message({ GSCommand::memdump_t,payload });
 
     GSReturnMessage data;
-    wait_for_return(return_queue, GSReturn::gsdump_render_partial_done_t, data);
+    gs_thread.wait_for_return(GSReturn::gsdump_render_partial_done_t, data);
+    
     width = data.payload.xy_payload.x;
     height = data.payload.xy_payload.y;
 
@@ -242,7 +198,8 @@ void GraphicsSynthesizer::write64(uint32_t addr, uint64_t value)
 {
     GSMessagePayload payload;
     payload.write64_payload = { addr, value };
-    send_message({ GSCommand::write64_t,payload });
+    
+    gs_thread.send_message({ GSCommand::write64_t, payload });
 
     //We need a check for SIGNAL here so that we can fire the interrupt
     if (addr == 0x60)
@@ -259,7 +216,8 @@ void GraphicsSynthesizer::write64_privileged(uint32_t addr, uint64_t value)
 {
     GSMessagePayload payload;
     payload.write64_payload = { addr, value };
-    send_message({ GSCommand::write64_privileged_t,payload });
+
+    gs_thread.send_message({ GSCommand::write64_privileged_t,payload });
 
     bool old_IMR = reg.IMR.signal;
     reg.write64_privileged(addr, value);
@@ -276,7 +234,8 @@ void GraphicsSynthesizer::write32_privileged(uint32_t addr, uint32_t value)
 {
     GSMessagePayload payload;
     payload.write32_payload = { addr, value };
-    send_message({ GSCommand::write32_privileged_t,payload });
+
+    gs_thread.send_message({ GSCommand::write32_privileged_t,payload });
 
     reg.write32_privileged(addr, value);
 }
@@ -295,65 +254,76 @@ void GraphicsSynthesizer::set_RGBA(uint8_t r, uint8_t g, uint8_t b, uint8_t a, f
 {
     GSMessagePayload payload;
     payload.rgba_payload = { r, g, b, a, q};
-    send_message({ GSCommand::set_rgba_t,payload });
+    
+    gs_thread.send_message({ GSCommand::set_rgba_t, payload });
 }
 
 void GraphicsSynthesizer::set_ST(uint32_t s, uint32_t t)
 {
     GSMessagePayload payload;
     payload.st_payload = { s, t };
-    send_message({ GSCommand::set_st_t,payload });
+    
+    gs_thread.send_message({ GSCommand::set_st_t, payload });
 }
 
 void GraphicsSynthesizer::set_UV(uint16_t u, uint16_t v)
 {
     GSMessagePayload payload;
     payload.uv_payload = { u, v };
-    send_message({ GSCommand::set_uv_t,payload });
+    
+    gs_thread.send_message({ GSCommand::set_uv_t, payload });
 }
 
 void GraphicsSynthesizer::set_XYZ(uint32_t x, uint32_t y, uint32_t z, bool drawing_kick)
 {
     GSMessagePayload payload;
     payload.xyz_payload = { x, y, z, drawing_kick };
-    send_message({ GSCommand::set_xyz_t,payload });
+    
+    gs_thread.send_message({ GSCommand::set_xyz_t, payload });
 }
 
 void GraphicsSynthesizer::set_XYZF(uint32_t x, uint32_t y, uint32_t z, uint8_t fog, bool drawing_kick)
 {
     GSMessagePayload payload;
     payload.xyzf_payload = { x, y, z, fog, drawing_kick };
-    send_message({ GSCommand::set_xyzf_t,payload });
+
+    gs_thread.send_message({ GSCommand::set_xyzf_t, payload });
 }
 
-void GraphicsSynthesizer::load_state(ifstream &state)
+void GraphicsSynthesizer::load_state(std::ifstream &state)
 {
     GSMessagePayload payload;
     payload.load_state_payload = {&state};
-    send_message({ GSCommand::load_state_t, payload});
+    gs_thread.send_message({ GSCommand::load_state_t, payload });
+    
     GSReturnMessage data;
-    wait_for_return(return_queue, GSReturn::load_state_done_t, data);
+    gs_thread.wait_for_return(GSReturn::load_state_done_t, data);
+    
     state.read((char*)&reg, sizeof(reg));
 }
 
-void GraphicsSynthesizer::save_state(ofstream &state)
+void GraphicsSynthesizer::save_state(std::ofstream &state)
 {
     GSMessagePayload payload;
     payload.save_state_payload = {&state};
-    send_message({ GSCommand::save_state_t,payload });
-    GSReturnMessage data;
-    wait_for_return(return_queue, GSReturn::save_state_done_t, data);
-    state.write((char*)&reg, sizeof(reg));
-}
 
-void GraphicsSynthesizer::send_message(GSMessage message)
-{
-    message_queue->push(message);
+    gs_thread.send_message({ GSCommand::save_state_t, payload });
+
+    GSReturnMessage data;
+    gs_thread.wait_for_return(GSReturn::save_state_done_t, data);
+    
+    state.write((char*)&reg, sizeof(reg));
 }
 
 void GraphicsSynthesizer::send_dump_request()
 {
     GSMessagePayload p;
     p.no_payload = { 0 };
-    send_message({ gsdump_t, p });
+
+    gs_thread.send_message({ gsdump_t, p });
+}
+
+void GraphicsSynthesizer::send_message(GSMessage message)
+{
+    gs_thread.send_message(message);
 }

--- a/src/core/gs.hpp
+++ b/src/core/gs.hpp
@@ -3,126 +3,10 @@
 #include <cstdint>
 #include <thread>
 #include <mutex>
-#include "gscontext.hpp"
+#include "gsthread.hpp"
 #include "gsregisters.hpp"
-#include "circularFIFO.hpp"
 
 class INTC;
-
-//Commands sent from the main thread to the GS thread.
-enum GSCommand:uint8_t 
-{
-	write64_t, write64_privileged_t, write32_privileged_t,
-    set_rgba_t, set_st_t, set_uv_t, set_xyz_t, set_xyzf_t, set_crt_t,
-    render_crt_t, assert_finish_t, assert_vsync_t, set_vblank_t, memdump_t, die_t,
-    save_state_t, load_state_t, gsdump_t
-};
-
-union GSMessagePayload 
-{
-    struct 
-	{
-        uint32_t addr;
-        uint64_t value;
-    } write64_payload;
-    struct 
-	{
-        uint32_t addr;
-        uint32_t value;
-    } write32_payload;
-    struct 
-	{
-        uint8_t r, g, b, a;
-        float q;
-    } rgba_payload;
-    struct 
-	{
-        uint32_t s, t;
-    } st_payload;
-    struct 
-	{
-        uint16_t u, v;
-    } uv_payload;
-    struct 
-	{
-        uint32_t x, y, z;
-        bool drawing_kick;
-    } xyz_payload;
-    struct
-    {
-        uint32_t x, y, z;
-        uint8_t fog;
-        bool drawing_kick;
-    } xyzf_payload;
-    struct 
-	{
-        bool interlaced;
-        int mode;
-        bool frame_mode;
-    } crt_payload;
-    struct 
-	{
-        bool vblank;
-    } vblank_payload;
-    struct 
-	{
-        uint32_t* target;
-        std::mutex* target_mutex;
-    } render_payload;
-    struct
-    {
-        std::ofstream* state;
-    } save_state_payload;
-    struct
-    {
-        std::ifstream* state;
-    } load_state_payload;
-    struct 
-	{
-        uint8_t BLANK; 
-    } no_payload;//C++ doesn't like the empty struct
-};
-
-struct GSMessage
-{
-    GSCommand type;
-    GSMessagePayload payload;
-};
-
-//Commands sent from the GS thread to the main thread.
-enum GSReturn :uint8_t
-{
-    render_complete_t,
-    death_error_t,
-    save_state_done_t,
-    load_state_done_t,
-    gsdump_render_partial_done_t,
-};
-
-union GSReturnMessagePayload
-{
-    struct
-    {
-        const char* error_str;
-    } death_error_payload;
-    struct
-    {
-        uint16_t x, y;
-    } xy_payload;
-    struct
-    {
-        uint8_t BLANK;
-    } no_payload;//C++ doesn't like the empty struct
-};
-
-struct GSReturnMessage
-{
-    GSReturn type;
-    GSReturnMessagePayload payload;
-};
-
-typedef CircularFifo<GSMessage, 1024 * 1024 * 16> gs_fifo;
-typedef CircularFifo<GSReturnMessage, 1024> gs_return_fifo;
 
 class GraphicsSynthesizer
 {
@@ -138,24 +22,21 @@ class GraphicsSynthesizer
 
         GS_REGISTERS reg;
 
-        gs_fifo* message_queue;
-        gs_return_fifo* return_queue;
-
-        std::thread gsthread_id;
+        GraphicsSynthesizerThread gs_thread;
     public:
         GraphicsSynthesizer(INTC* intc);
         ~GraphicsSynthesizer();
-        void send_message(GSMessage message);
+
         void reset();
         void start_frame();
-        bool is_frame_complete();
+        bool is_frame_complete() const;
         uint32_t* get_framebuffer();
         void render_CRT();
         uint32_t* render_partial_frame(uint16_t& width, uint16_t& height);
         void get_resolution(int& w, int& h);
         void get_inner_resolution(int& w, int& h);
 
-        bool stalled();
+        inline bool stalled() { return reg.CSR.SIGNAL_stall; }
 
         void set_VBLANK(bool is_VBLANK);
         void assert_FINISH();
@@ -178,12 +59,7 @@ class GraphicsSynthesizer
         void load_state(std::ifstream& state);
         void save_state(std::ofstream& state);
         void send_dump_request();
-        
+
+        void send_message(GSMessage message);
 };
-
-inline bool GraphicsSynthesizer::stalled()
-{
-    return reg.CSR.SIGNAL_stall;
-}
-
 #endif // GS_HPP


### PR DESCRIPTION
- Refactor some of the threading code so it's contained within the GraphicsSynthesizerThread class.
- Set wait_for_return and event_loop to use condition variables to prevent spinning the thread when there is no work to be done.
- Some general cleanup

Fixes #150