### PR TITLE
Fixed up EE/IOP timer edge cases

### DIFF
--- a/DobieStation/DobieStation.sln
+++ b/DobieStation/DobieStation.sln
@@ -13,20 +13,20 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
-		Release Optimised|x64 = Release Optimised|x64
+		Release Optimized|x64 = Release Optimized|x64
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{353E9072-F9AB-35F7-8AFF-FAC3EA8AFEE0}.Debug|x64.ActiveCfg = Debug|x64
 		{353E9072-F9AB-35F7-8AFF-FAC3EA8AFEE0}.Debug|x64.Build.0 = Debug|x64
-		{353E9072-F9AB-35F7-8AFF-FAC3EA8AFEE0}.Release Optimised|x64.ActiveCfg = Release Optimised|x64
-		{353E9072-F9AB-35F7-8AFF-FAC3EA8AFEE0}.Release Optimised|x64.Build.0 = Release Optimised|x64
+		{353E9072-F9AB-35F7-8AFF-FAC3EA8AFEE0}.Release Optimized|x64.ActiveCfg = Release Optimised|x64
+		{353E9072-F9AB-35F7-8AFF-FAC3EA8AFEE0}.Release Optimized|x64.Build.0 = Release Optimised|x64
 		{353E9072-F9AB-35F7-8AFF-FAC3EA8AFEE0}.Release|x64.ActiveCfg = Release|x64
 		{353E9072-F9AB-35F7-8AFF-FAC3EA8AFEE0}.Release|x64.Build.0 = Release|x64
 		{A77564F4-56BB-3D08-8126-3FD5FC44F217}.Debug|x64.ActiveCfg = Debug|x64
 		{A77564F4-56BB-3D08-8126-3FD5FC44F217}.Debug|x64.Build.0 = Debug|x64
-		{A77564F4-56BB-3D08-8126-3FD5FC44F217}.Release Optimised|x64.ActiveCfg = Release Optimised|x64
-		{A77564F4-56BB-3D08-8126-3FD5FC44F217}.Release Optimised|x64.Build.0 = Release Optimised|x64
+		{A77564F4-56BB-3D08-8126-3FD5FC44F217}.Release Optimized|x64.ActiveCfg = Release Optimised|x64
+		{A77564F4-56BB-3D08-8126-3FD5FC44F217}.Release Optimized|x64.Build.0 = Release Optimised|x64
 		{A77564F4-56BB-3D08-8126-3FD5FC44F217}.Release|x64.ActiveCfg = Release|x64
 		{A77564F4-56BB-3D08-8126-3FD5FC44F217}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection

--- a/DobieStation/DobieStation.sln
+++ b/DobieStation/DobieStation.sln
@@ -13,15 +13,20 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
+		Release Optimised|x64 = Release Optimised|x64
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{353E9072-F9AB-35F7-8AFF-FAC3EA8AFEE0}.Debug|x64.ActiveCfg = Debug|x64
 		{353E9072-F9AB-35F7-8AFF-FAC3EA8AFEE0}.Debug|x64.Build.0 = Debug|x64
+		{353E9072-F9AB-35F7-8AFF-FAC3EA8AFEE0}.Release Optimised|x64.ActiveCfg = Release Optimised|x64
+		{353E9072-F9AB-35F7-8AFF-FAC3EA8AFEE0}.Release Optimised|x64.Build.0 = Release Optimised|x64
 		{353E9072-F9AB-35F7-8AFF-FAC3EA8AFEE0}.Release|x64.ActiveCfg = Release|x64
 		{353E9072-F9AB-35F7-8AFF-FAC3EA8AFEE0}.Release|x64.Build.0 = Release|x64
 		{A77564F4-56BB-3D08-8126-3FD5FC44F217}.Debug|x64.ActiveCfg = Debug|x64
 		{A77564F4-56BB-3D08-8126-3FD5FC44F217}.Debug|x64.Build.0 = Debug|x64
+		{A77564F4-56BB-3D08-8126-3FD5FC44F217}.Release Optimised|x64.ActiveCfg = Release Optimised|x64
+		{A77564F4-56BB-3D08-8126-3FD5FC44F217}.Release Optimised|x64.Build.0 = Release Optimised|x64
 		{A77564F4-56BB-3D08-8126-3FD5FC44F217}.Release|x64.ActiveCfg = Release|x64
 		{A77564F4-56BB-3D08-8126-3FD5FC44F217}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection

--- a/DobieStation/DobieStation.sln
+++ b/DobieStation/DobieStation.sln
@@ -19,14 +19,14 @@ Global
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{353E9072-F9AB-35F7-8AFF-FAC3EA8AFEE0}.Debug|x64.ActiveCfg = Debug|x64
 		{353E9072-F9AB-35F7-8AFF-FAC3EA8AFEE0}.Debug|x64.Build.0 = Debug|x64
-		{353E9072-F9AB-35F7-8AFF-FAC3EA8AFEE0}.Release Optimized|x64.ActiveCfg = Release Optimised|x64
-		{353E9072-F9AB-35F7-8AFF-FAC3EA8AFEE0}.Release Optimized|x64.Build.0 = Release Optimised|x64
+		{353E9072-F9AB-35F7-8AFF-FAC3EA8AFEE0}.Release Optimized|x64.ActiveCfg = Release Optimized|x64
+		{353E9072-F9AB-35F7-8AFF-FAC3EA8AFEE0}.Release Optimized|x64.Build.0 = Release Optimized|x64
 		{353E9072-F9AB-35F7-8AFF-FAC3EA8AFEE0}.Release|x64.ActiveCfg = Release|x64
 		{353E9072-F9AB-35F7-8AFF-FAC3EA8AFEE0}.Release|x64.Build.0 = Release|x64
 		{A77564F4-56BB-3D08-8126-3FD5FC44F217}.Debug|x64.ActiveCfg = Debug|x64
 		{A77564F4-56BB-3D08-8126-3FD5FC44F217}.Debug|x64.Build.0 = Debug|x64
-		{A77564F4-56BB-3D08-8126-3FD5FC44F217}.Release Optimized|x64.ActiveCfg = Release Optimised|x64
-		{A77564F4-56BB-3D08-8126-3FD5FC44F217}.Release Optimized|x64.Build.0 = Release Optimised|x64
+		{A77564F4-56BB-3D08-8126-3FD5FC44F217}.Release Optimized|x64.ActiveCfg = Release Optimized|x64
+		{A77564F4-56BB-3D08-8126-3FD5FC44F217}.Release Optimized|x64.Build.0 = Release Optimized|x64
 		{A77564F4-56BB-3D08-8126-3FD5FC44F217}.Release|x64.ActiveCfg = Release|x64
 		{A77564F4-56BB-3D08-8126-3FD5FC44F217}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection

--- a/DobieStation/DobieStation.vcxproj
+++ b/DobieStation/DobieStation.vcxproj
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Release Optimised|x64">
-      <Configuration>Release Optimised</Configuration>
+    <ProjectConfiguration Include="Release Optimized|x64">
+      <Configuration>Release Optimized</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
@@ -28,7 +28,7 @@
     <IntermediateDirectory>release\</IntermediateDirectory>
     <PrimaryOutput>DobieStation</PrimaryOutput>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Optimised|x64'" Label="Configuration">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Optimized|x64'" Label="Configuration">
     <PlatformToolset>v141</PlatformToolset>
     <OutputDirectory>release\</OutputDirectory>
     <ATLMinimizesCRunTimeLibraryUsage>false</ATLMinimizesCRunTimeLibraryUsage>
@@ -58,15 +58,15 @@
   </PropertyGroup>
   <PropertyGroup>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">release\</OutDir>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release Optimised|x64'">release\</OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release Optimized|x64'">release\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(Platform)\$(Configuration)\</IntDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release Optimised|x64'">$(Platform)\$(Configuration)\</IntDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release Optimized|x64'">$(Platform)\$(Configuration)\</IntDir>
     <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">DobieStation</TargetName>
-    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release Optimised|x64'">DobieStation</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release Optimized|x64'">DobieStation</TargetName>
     <IgnoreImportLibrary Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</IgnoreImportLibrary>
-    <IgnoreImportLibrary Condition="'$(Configuration)|$(Platform)'=='Release Optimised|x64'">true</IgnoreImportLibrary>
+    <IgnoreImportLibrary Condition="'$(Configuration)|$(Platform)'=='Release Optimized|x64'">true</IgnoreImportLibrary>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</LinkIncremental>
-    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release Optimised|x64'">false</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release Optimized|x64'">false</LinkIncremental>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">debug\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(Platform)\$(Configuration)\</IntDir>
     <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">DobieStation</TargetName>
@@ -92,11 +92,6 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AdditionalIncludeDirectories>$(ProjectDir)\..\src\qt;$(ProjectDir)\..\ext\libdeflate;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
-      <IntrinsicFunctions>false</IntrinsicFunctions>
-      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
-      <WholeProgramOptimization>true</WholeProgramOptimization>
-      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
     </ClCompile>
     <Link>
       <AdditionalDependencies>.\libdeflate\release\libdeflate.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -109,7 +104,6 @@
       <RandomizedBaseAddress>true</RandomizedBaseAddress>
       <SubSystem>Console</SubSystem>
       <SuppressStartupBanner>true</SuppressStartupBanner>
-      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
     <Midl>
       <DefaultCharType>Unsigned</DefaultCharType>
@@ -120,7 +114,7 @@
       <PreprocessorDefinitions>_CONSOLE;UNICODE;_UNICODE;WIN32;WIN64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release Optimised|x64'">
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release Optimized|x64'">
     <ClCompile>
       <AdditionalOptions>-Zc:rvalueCast -Zc:inline -Zc:strictStrings -Zc:throwingNew -Zc:referenceBinding -w34100 -w34189 -w44996 -w44456 -w44457 -w44458 %(AdditionalOptions)</AdditionalOptions>
       <AssemblerListingLocation>release\</AssemblerListingLocation>
@@ -140,6 +134,10 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <AdditionalIncludeDirectories>$(ProjectDir)\..\src\qt;$(ProjectDir)\..\ext\libdeflate;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
+      <IntrinsicFunctions>false</IntrinsicFunctions>
     </ClCompile>
     <Link>
       <AdditionalDependencies>.\libdeflate\release\libdeflate.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -152,6 +150,7 @@
       <RandomizedBaseAddress>true</RandomizedBaseAddress>
       <SubSystem>Console</SubSystem>
       <SuppressStartupBanner>true</SuppressStartupBanner>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
     <Midl>
       <DefaultCharType>Unsigned</DefaultCharType>

--- a/DobieStation/DobieStation.vcxproj
+++ b/DobieStation/DobieStation.vcxproj
@@ -1,6 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Release Optimised|x64">
+      <Configuration>Release Optimised</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -16,6 +20,15 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <PlatformToolset>v141</PlatformToolset>
+    <OutputDirectory>release\</OutputDirectory>
+    <ATLMinimizesCRunTimeLibraryUsage>false</ATLMinimizesCRunTimeLibraryUsage>
+    <CharacterSet>NotSet</CharacterSet>
+    <ConfigurationType>Application</ConfigurationType>
+    <IntermediateDirectory>release\</IntermediateDirectory>
+    <PrimaryOutput>DobieStation</PrimaryOutput>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Optimised|x64'" Label="Configuration">
     <PlatformToolset>v141</PlatformToolset>
     <OutputDirectory>release\</OutputDirectory>
     <ATLMinimizesCRunTimeLibraryUsage>false</ATLMinimizesCRunTimeLibraryUsage>
@@ -45,16 +58,69 @@
   </PropertyGroup>
   <PropertyGroup>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">release\</OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release Optimised|x64'">release\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(Platform)\$(Configuration)\</IntDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release Optimised|x64'">$(Platform)\$(Configuration)\</IntDir>
     <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">DobieStation</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release Optimised|x64'">DobieStation</TargetName>
     <IgnoreImportLibrary Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</IgnoreImportLibrary>
+    <IgnoreImportLibrary Condition="'$(Configuration)|$(Platform)'=='Release Optimised|x64'">true</IgnoreImportLibrary>
     <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</LinkIncremental>
+    <LinkIncremental Condition="'$(Configuration)|$(Platform)'=='Release Optimised|x64'">false</LinkIncremental>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">debug\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(Platform)\$(Configuration)\</IntDir>
     <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">DobieStation</TargetName>
     <IgnoreImportLibrary Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</IgnoreImportLibrary>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalOptions>-Zc:rvalueCast -Zc:inline -Zc:strictStrings -Zc:throwingNew -Zc:referenceBinding -w34100 -w34189 -w44996 -w44456 -w44457 -w44458 %(AdditionalOptions)</AdditionalOptions>
+      <AssemblerListingLocation>release\</AssemblerListingLocation>
+      <BrowseInformation>false</BrowseInformation>
+      <DebugInformationFormat>None</DebugInformationFormat>
+      <DisableSpecificWarnings>4577;4467;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <ObjectFileName>$(IntDir)</ObjectFileName>
+      <Optimization>MaxSpeed</Optimization>
+      <PreprocessorDefinitions>_CONSOLE;UNICODE;_UNICODE;WIN32;WIN64;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessToFile>false</PreprocessToFile>
+      <ProgramDataBaseFileName>$(IntDir)vc$(PlatformToolsetVersion).pdb</ProgramDataBaseFileName>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
+      <WarningLevel>Level3</WarningLevel>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalIncludeDirectories>$(ProjectDir)\..\src\qt;$(ProjectDir)\..\ext\libdeflate;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
+      <InlineFunctionExpansion>AnySuitable</InlineFunctionExpansion>
+      <IntrinsicFunctions>false</IntrinsicFunctions>
+      <EnableFiberSafeOptimizations>true</EnableFiberSafeOptimizations>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
+      <EnableEnhancedInstructionSet>NotSet</EnableEnhancedInstructionSet>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>.\libdeflate\release\libdeflate.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalOptions>"/MANIFESTDEPENDENCY:type='win32' name='Microsoft.Windows.Common-Controls' version='6.0.0.0' publicKeyToken='6595b64144ccf1df' language='*' processorArchitecture='*'" %(AdditionalOptions)</AdditionalOptions>
+      <DataExecutionPrevention>true</DataExecutionPrevention>
+      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <IgnoreImportLibrary>true</IgnoreImportLibrary>
+      <LinkIncremental>false</LinkIncremental>
+      <OutputFile>$(OutDir)\DobieStation.exe</OutputFile>
+      <RandomizedBaseAddress>true</RandomizedBaseAddress>
+      <SubSystem>Console</SubSystem>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+    </Link>
+    <Midl>
+      <DefaultCharType>Unsigned</DefaultCharType>
+      <EnableErrorChecks>None</EnableErrorChecks>
+      <WarningLevel>0</WarningLevel>
+    </Midl>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_CONSOLE;UNICODE;_UNICODE;WIN32;WIN64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release Optimised|x64'">
     <ClCompile>
       <AdditionalOptions>-Zc:rvalueCast -Zc:inline -Zc:strictStrings -Zc:throwingNew -Zc:referenceBinding -w34100 -w34189 -w44996 -w44456 -w44457 -w44458 %(AdditionalOptions)</AdditionalOptions>
       <AssemblerListingLocation>release\</AssemblerListingLocation>
@@ -164,7 +230,7 @@
     <ClCompile Include="..\src\qt\emuwindow.cpp" />
     <ClCompile Include="..\src\qt\renderwidget.cpp" />
     <ClCompile Include="..\src\qt\settingswindow.cpp" />
-	<ClCompile Include="..\src\qt\gamelistwidget.cpp" />
+    <ClCompile Include="..\src\qt\gamelistwidget.cpp" />
     <ClCompile Include="..\src\qt\bios.cpp" />
     <ClCompile Include="..\src\core\errors.cpp" />
     <ClCompile Include="..\src\core\iop\gamepad.cpp" />
@@ -207,24 +273,24 @@
     <ClCompile Include="..\src\core\ee\vu_jit.cpp" />
     <ClCompile Include="..\src\core\ee\vu_jit64.cpp" />
     <ClCompile Include="..\src\core\ee\vu_jittrans.cpp" />
-	<ClCompile Include="..\src\core\scheduler.cpp" />
+    <ClCompile Include="..\src\core\scheduler.cpp" />
   </ItemGroup>
   <!-- moc files -->
   <ItemGroup>
-	<QtMoc Include="..\src\qt\settings.hpp" />
+    <QtMoc Include="..\src\qt\settings.hpp" />
     <QtMoc Include="..\src\qt\emuthread.hpp" />
     <QtMoc Include="..\src\qt\emuwindow.hpp" />
     <QtMoc Include="..\src\qt\renderwidget.hpp" />
     <QtMoc Include="..\src\qt\settingswindow.hpp" />
-	<QtMoc Include="..\src\qt\gamelistwidget.hpp" />
+    <QtMoc Include="..\src\qt\gamelistwidget.hpp" />
   </ItemGroup>
   <ItemGroup>
-	<ClCompile Include="$(QtMocOutPrefix)settings.cpp" />
+    <ClCompile Include="$(QtMocOutPrefix)settings.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)emuthread.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)emuwindow.cpp" />
-	<ClCompile Include="$(QtMocOutPrefix)renderwidget.cpp" />
+    <ClCompile Include="$(QtMocOutPrefix)renderwidget.cpp" />
     <ClCompile Include="$(QtMocOutPrefix)settingswindow.cpp" />
-	<ClCompile Include="$(QtMocOutPrefix)gamelistwidget.cpp" />
+    <ClCompile Include="$(QtMocOutPrefix)gamelistwidget.cpp" />
   </ItemGroup>
   <!-- headers -->
   <ItemGroup>
@@ -286,13 +352,13 @@
     <ClInclude Include="..\src\core\ee\vu_jit.hpp" />
     <ClInclude Include="..\src\core\ee\vu_jit64.hpp" />
     <ClInclude Include="..\src\core\ee\vu_jittrans.hpp" />
-	<ClInclude Include="..\src\core\scheduler.hpp" />
+    <ClInclude Include="..\src\core\scheduler.hpp" />
   </ItemGroup>
   <!-- jit stuff -->
   <ItemGroup>
     <None Include="..\README.md" />
     <None Include="..\src\core\jitcommon\ir_instrlist.inc" />
-	<None Include="..\appveyor.yml" />
+    <None Include="..\appveyor.yml" />
   </ItemGroup>
   <ItemGroup>
     <MASM Include="..\src\core\ee\vu_jit_asm.asm" />

--- a/DobieStation/libdeflate/libdeflate.vcxproj
+++ b/DobieStation/libdeflate/libdeflate.vcxproj
@@ -1,6 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Release Optimised|x64">
+      <Configuration>Release Optimised</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
       <Platform>x64</Platform>
@@ -24,6 +28,15 @@
     <IntermediateDirectory>release\</IntermediateDirectory>
     <PrimaryOutput>libdeflate</PrimaryOutput>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Optimised|x64'" Label="Configuration">
+    <PlatformToolset>v141</PlatformToolset>
+    <OutputDirectory>release\</OutputDirectory>
+    <ATLMinimizesCRunTimeLibraryUsage>false</ATLMinimizesCRunTimeLibraryUsage>
+    <CharacterSet>NotSet</CharacterSet>
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <IntermediateDirectory>release\</IntermediateDirectory>
+    <PrimaryOutput>libdeflate</PrimaryOutput>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <PlatformToolset>v141</PlatformToolset>
     <OutputDirectory>debug\</OutputDirectory>
@@ -38,21 +51,61 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
   </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release Optimised|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
+  </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">.\release\</OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release Optimised|x64'">.\release\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(Platform)\$(Configuration)\</IntDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release Optimised|x64'">$(Platform)\$(Configuration)\</IntDir>
     <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">libdeflate</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release Optimised|x64'">libdeflate</TargetName>
     <IgnoreImportLibrary Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</IgnoreImportLibrary>
+    <IgnoreImportLibrary Condition="'$(Configuration)|$(Platform)'=='Release Optimised|x64'">true</IgnoreImportLibrary>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">.\debug\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(Platform)\$(Configuration)\</IntDir>
     <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">libdeflate</TargetName>
     <IgnoreImportLibrary Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</IgnoreImportLibrary>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>.\GeneratedFiles\$(ConfigurationName);.\GeneratedFiles;.;..\..\ext\libdeflate;..\..\ext\libdeflate\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>-Zc:rvalueCast -Zc:inline -Zc:strictStrings -Zc:throwingNew -Zc:referenceBinding -w34100 -w34189 -w44996 -w44456 -w44457 -w44458 %(AdditionalOptions)</AdditionalOptions>
+      <AssemblerListingLocation>release\</AssemblerListingLocation>
+      <BrowseInformation>false</BrowseInformation>
+      <DebugInformationFormat>None</DebugInformationFormat>
+      <DisableSpecificWarnings>4577;4467;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <ExceptionHandling>Sync</ExceptionHandling>
+      <ObjectFileName>$(IntDir)</ObjectFileName>
+      <Optimization>MaxSpeed</Optimization>
+      <PreprocessorDefinitions>_WINDOWS;UNICODE;_UNICODE;WIN32;WIN64;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessToFile>false</PreprocessToFile>
+      <ProgramDataBaseFileName>$(IntDir)vc$(PlatformToolsetVersion).pdb</ProgramDataBaseFileName>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+      <TreatWChar_tAsBuiltInType>true</TreatWChar_tAsBuiltInType>
+      <WarningLevel>Level2</WarningLevel>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Lib>
+      <OutputFile>$(OutDir)\libdeflate.lib</OutputFile>
+      <SuppressStartupBanner>true</SuppressStartupBanner>
+    </Lib>
+    <Midl>
+      <DefaultCharType>Unsigned</DefaultCharType>
+      <EnableErrorChecks>None</EnableErrorChecks>
+      <WarningLevel>0</WarningLevel>
+    </Midl>
+    <ResourceCompile>
+      <PreprocessorDefinitions>_WINDOWS;UNICODE;_UNICODE;WIN32;WIN64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release Optimised|x64'">
     <ClCompile>
       <AdditionalIncludeDirectories>.\GeneratedFiles\$(ConfigurationName);.\GeneratedFiles;.;..\..\ext\libdeflate;..\..\ext\libdeflate\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>-Zc:rvalueCast -Zc:inline -Zc:strictStrings -Zc:throwingNew -Zc:referenceBinding -w34100 -w34189 -w44996 -w44456 -w44457 -w44458 %(AdditionalOptions)</AdditionalOptions>

--- a/DobieStation/libdeflate/libdeflate.vcxproj
+++ b/DobieStation/libdeflate/libdeflate.vcxproj
@@ -1,8 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
-    <ProjectConfiguration Include="Release Optimised|x64">
-      <Configuration>Release Optimised</Configuration>
+    <ProjectConfiguration Include="Release Optimized|x64">
+      <Configuration>Release Optimized</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
@@ -28,7 +28,7 @@
     <IntermediateDirectory>release\</IntermediateDirectory>
     <PrimaryOutput>libdeflate</PrimaryOutput>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Optimised|x64'" Label="Configuration">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Optimized|x64'" Label="Configuration">
     <PlatformToolset>v141</PlatformToolset>
     <OutputDirectory>release\</OutputDirectory>
     <ATLMinimizesCRunTimeLibraryUsage>false</ATLMinimizesCRunTimeLibraryUsage>
@@ -51,7 +51,7 @@
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
   </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release Optimised|x64'" Label="PropertySheets">
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release Optimized|x64'" Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
   </ImportGroup>
   <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
@@ -60,13 +60,13 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">.\release\</OutDir>
-    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release Optimised|x64'">.\release\</OutDir>
+    <OutDir Condition="'$(Configuration)|$(Platform)'=='Release Optimized|x64'">.\release\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(Platform)\$(Configuration)\</IntDir>
-    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release Optimised|x64'">$(Platform)\$(Configuration)\</IntDir>
+    <IntDir Condition="'$(Configuration)|$(Platform)'=='Release Optimized|x64'">$(Platform)\$(Configuration)\</IntDir>
     <TargetName Condition="'$(Configuration)|$(Platform)'=='Release|x64'">libdeflate</TargetName>
-    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release Optimised|x64'">libdeflate</TargetName>
+    <TargetName Condition="'$(Configuration)|$(Platform)'=='Release Optimized|x64'">libdeflate</TargetName>
     <IgnoreImportLibrary Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</IgnoreImportLibrary>
-    <IgnoreImportLibrary Condition="'$(Configuration)|$(Platform)'=='Release Optimised|x64'">true</IgnoreImportLibrary>
+    <IgnoreImportLibrary Condition="'$(Configuration)|$(Platform)'=='Release Optimized|x64'">true</IgnoreImportLibrary>
     <OutDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">.\debug\</OutDir>
     <IntDir Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(Platform)\$(Configuration)\</IntDir>
     <TargetName Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">libdeflate</TargetName>
@@ -105,7 +105,7 @@
       <PreprocessorDefinitions>_WINDOWS;UNICODE;_UNICODE;WIN32;WIN64;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release Optimised|x64'">
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release Optimized|x64'">
     <ClCompile>
       <AdditionalIncludeDirectories>.\GeneratedFiles\$(ConfigurationName);.\GeneratedFiles;.;..\..\ext\libdeflate;..\..\ext\libdeflate\common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>-Zc:rvalueCast -Zc:inline -Zc:strictStrings -Zc:throwingNew -Zc:referenceBinding -w34100 -w34189 -w44996 -w44456 -w44457 -w44458 %(AdditionalOptions)</AdditionalOptions>

--- a/src/core/ee/timers.hpp
+++ b/src/core/ee/timers.hpp
@@ -49,7 +49,6 @@ class EmotionTiming
 
         void update_timers();
         void reschedule();
-        void count_up(int index);
     public:
         EmotionTiming(INTC* intc);
 

--- a/src/core/ee/vu_jit64.cpp
+++ b/src/core/ee/vu_jit64.cpp
@@ -32,7 +32,7 @@
  */
 
 #ifdef _WIN32
-    extern "C" void run_vu_jit();
+    extern "C" void run_vu_jit(VU_JIT64& jit, VectorUnit& vu);
 #endif
 
 VU_JIT64::VU_JIT64() : emitter(&cache)
@@ -3110,7 +3110,7 @@ uint8_t* exec_block(VU_JIT64& jit, VectorUnit& vu)
 uint16_t VU_JIT64::run(VectorUnit& vu)
 {
 #ifdef _MSC_VER
-    run_vu_jit();
+    run_vu_jit(*this, vu);
 #else
     uint8_t* block = exec_block(*this, vu);
 

--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -20,7 +20,7 @@ Emulator::Emulator() :
     dmac(&cpu, this, &gif, &ipu, &sif, &vif0, &vif1, &vu0, &vu1), gif(&gs), gs(&intc),
     iop(this), iop_dma(this, &cdvd, &sif, &sio2, &spu, &spu2), iop_timers(this), intc(this, &cpu), ipu(&intc),
     timers(&intc), sio2(this, &pad, &memcard), spu(1, this, &iop_dma), spu2(2, this, &iop_dma),
-    vif0(nullptr, &vu0, &intc, 0), vif1(&gif, &vu1, &intc, 1), vu0(0, this, &intc, &cpu), vu1(1, this, &intc, &cpu), sif(&iop_dma)
+    vif0(&gif, &vu0, &intc, 0), vif1(&gif, &vu1, &intc, 1), vu0(0, this, &intc, &cpu), vu1(1, this, &intc, &cpu), sif(&iop_dma)
 {
     BIOS = nullptr;
     RDRAM = nullptr;

--- a/src/core/gscontext.cpp
+++ b/src/core/gscontext.cpp
@@ -38,7 +38,7 @@ void GSContext::set_tex0(uint64_t value)
     tex0.CLUT_base = ((value >> 37) & 0x3FFF) * 64 * 4;
     tex0.CLUT_format = (value >> 51) & 0xF;
     tex0.use_CSM2 = (value >> 55) & 0x1;
-    if(!tex0.CLUT_format)
+    if (!tex0.CLUT_format)
         tex0.CLUT_offset = ((value >> 56) & 0xF) * 16 * 2;
     else
         tex0.CLUT_offset = ((value >> 56) & 0x1F) * 16;

--- a/src/core/gscontext.cpp
+++ b/src/core/gscontext.cpp
@@ -38,7 +38,10 @@ void GSContext::set_tex0(uint64_t value)
     tex0.CLUT_base = ((value >> 37) & 0x3FFF) * 64 * 4;
     tex0.CLUT_format = (value >> 51) & 0xF;
     tex0.use_CSM2 = (value >> 55) & 0x1;
-    tex0.CLUT_offset = ((value >> 56) & 0x1F) * 16;
+    if(!tex0.CLUT_format)
+        tex0.CLUT_offset = ((value >> 56) & 0xF) * 16 * 2;
+    else
+        tex0.CLUT_offset = ((value >> 56) & 0x1F) * 16;
     tex0.CLUT_control = (value >> 61) & 0x7;
 
     printf("TEX0: $%08X_%08X\n", value >> 32, value & 0xFFFFFFFF);
@@ -74,7 +77,10 @@ void GSContext::set_tex2(uint64_t value)
     tex0.CLUT_base = ((value >> 37) & 0x3FFF) * 64 * 4;
     tex0.CLUT_format = (value >> 51) & 0xF;
     tex0.use_CSM2 = (value >> 55) & 0x1;
-    tex0.CLUT_offset = ((value >> 56) & 0x1F) * 16;
+    if (!tex0.CLUT_format)
+        tex0.CLUT_offset = ((value >> 56) & 0xF) * 16 * 2;
+    else
+        tex0.CLUT_offset = ((value >> 56) & 0x1F) * 16;
     tex0.CLUT_control = (value >> 61) & 0x7;
 
     printf("TEX2: $%08X_%08X\n", value >> 32, value);

--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -2629,8 +2629,8 @@ void GraphicsSynthesizerThread::tex_lookup_int(int16_t u, int16_t v, TexLookupIn
             u &= info.tex_width - 1;
             break;
         case 1:
-            if (u > info.tex_width)
-                u = info.tex_width;
+            if (u >= info.tex_width)
+                u = info.tex_width-1;
             else if (u < 0)
                 u = 0;
             break;
@@ -2651,8 +2651,8 @@ void GraphicsSynthesizerThread::tex_lookup_int(int16_t u, int16_t v, TexLookupIn
             v &= info.tex_height - 1;
             break;
         case 1:
-            if (v > info.tex_height)
-                v = info.tex_height;
+            if (v >= info.tex_height)
+                v = info.tex_height-1;
             else if (v < 0)
                 v = 0;
             break;

--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -2667,7 +2667,7 @@ void GraphicsSynthesizerThread::tex_lookup_int(int16_t u, int16_t v, TexLookupIn
             break;
     }
 
-    if (!info.new_lookup)
+    if (!info.new_lookup && !forced_lookup)
     {
         //if it's the same texture position, we already have the info, no need to look it up again
         if (u == info.lastu && v == info.lastv)

--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -2504,16 +2504,16 @@ void GraphicsSynthesizerThread::tex_lookup(int16_t u, int16_t v, TexLookupInfo& 
         int16_t uu = (u - 8) >> 4;
         int16_t vv = (v - 8) >> 4;
 
-        tex_lookup_int(uu, vv, info, true);
+        tex_lookup_int(uu, vv, info);
         a = info.srctex_color;
 
-        tex_lookup_int(uu + 1, vv, info, true);
+        tex_lookup_int(uu + 1, vv, info);
         b = info.srctex_color;
 
-        tex_lookup_int(uu, vv + 1, info, true);
+        tex_lookup_int(uu, vv + 1, info);
         c = info.srctex_color;
 
-        tex_lookup_int(uu + 1, vv + 1, info, true);
+        tex_lookup_int(uu + 1, vv + 1, info);
         d = info.srctex_color;
 
         double alpha = ((u - 8) & 0xF) * (1.0 / ((double)0xF));
@@ -2606,18 +2606,8 @@ void GraphicsSynthesizerThread::tex_lookup(int16_t u, int16_t v, TexLookupInfo& 
     }
 }
 
-void GraphicsSynthesizerThread::tex_lookup_int(int16_t u, int16_t v, TexLookupInfo& info, bool forced_lookup)
+void GraphicsSynthesizerThread::tex_lookup_int(int16_t u, int16_t v, TexLookupInfo& info)
 {
-    if (!info.new_lookup && !forced_lookup)
-    {
-        //if it's the same texture, we already have the info, no need to look it up again
-        if (u == info.lastu && v == info.lastv)
-            return;
-    }
-    info.lastu = u;
-    info.lastv = v;
-    info.new_lookup = false;
-
     switch (current_ctx->clamp.wrap_s)
     {
         case 0:
@@ -2661,6 +2651,16 @@ void GraphicsSynthesizerThread::tex_lookup_int(int16_t u, int16_t v, TexLookupIn
             v = (v & (current_ctx->clamp.min_v | 0xF)) | current_ctx->clamp.max_v;
             break;
     }
+
+    if (!info.new_lookup)
+    {
+        //if it's the same texture position, we already have the info, no need to look it up again
+        if (u == info.lastu && v == info.lastv)
+            return;
+    }
+    info.lastu = u;
+    info.lastv = v;
+    info.new_lookup = false;
 
     uint32_t tex_base = info.tex_base;
     uint32_t width = info.buffer_width;

--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -2520,10 +2520,10 @@ void GraphicsSynthesizerThread::tex_lookup(int16_t u, int16_t v, TexLookupInfo& 
         double beta = ((v - 8) & 0xF) * (1.0 / ((double)0xF));
         double alpha_s = 1.0 - alpha;
         double beta_s = 1.0 - beta;
-        info.tex_color.r = alpha_s * beta_s*a.r + alpha * beta_s*b.r + alpha_s * beta*c.r + alpha * beta*d.r;
-        info.tex_color.g = alpha_s * beta_s*a.g + alpha * beta_s*b.g + alpha_s * beta*c.g + alpha * beta*d.g;
-        info.tex_color.b = alpha_s * beta_s*a.b + alpha * beta_s*b.b + alpha_s * beta*c.b + alpha * beta*d.b;
-        info.tex_color.a = alpha_s * beta_s*a.a + alpha * beta_s*b.a + alpha_s * beta*c.a + alpha * beta*d.a;
+        info.srctex_color.r = alpha_s * beta_s*a.r + alpha * beta_s*b.r + alpha_s * beta*c.r + alpha * beta*d.r;
+        info.srctex_color.g = alpha_s * beta_s*a.g + alpha * beta_s*b.g + alpha_s * beta*c.g + alpha * beta*d.g;
+        info.srctex_color.b = alpha_s * beta_s*a.b + alpha * beta_s*b.b + alpha_s * beta*c.b + alpha * beta*d.b;
+        info.srctex_color.a = alpha_s * beta_s*a.a + alpha * beta_s*b.a + alpha_s * beta*c.a + alpha * beta*d.a;
     }
     else //If we already have looked up the texture at this location and messed with it, no point in doing it again
         tex_lookup_int(u >> 4, v >> 4, info);
@@ -2552,6 +2552,11 @@ void GraphicsSynthesizerThread::tex_lookup(int16_t u, int16_t v, TexLookupInfo& 
         case 1: //Decal
             if (!current_ctx->tex0.use_alpha)
                 info.tex_color.a = info.vtx_color.a;
+            else
+                info.tex_color.a = info.srctex_color.a;
+            info.tex_color.r = info.srctex_color.r;
+            info.tex_color.g = info.srctex_color.g;
+            info.tex_color.b = info.srctex_color.b;
             break;
         case 2: //Highlight
             info.tex_color.r = ((info.srctex_color.r * info.vtx_color.r) >> 7) + info.vtx_color.a;
@@ -2560,7 +2565,7 @@ void GraphicsSynthesizerThread::tex_lookup(int16_t u, int16_t v, TexLookupInfo& 
             if (!current_ctx->tex0.use_alpha)
                 info.tex_color.a = info.vtx_color.a;
             else
-                info.tex_color.a += info.vtx_color.a;
+                info.tex_color.a = info.srctex_color.a + info.vtx_color.a;
 
             if (info.tex_color.r > 0xFF)
                 info.tex_color.r = 0xFF;
@@ -2577,6 +2582,8 @@ void GraphicsSynthesizerThread::tex_lookup(int16_t u, int16_t v, TexLookupInfo& 
             info.tex_color.b = ((info.srctex_color.b * info.vtx_color.b) >> 7) + info.vtx_color.a;
             if (!current_ctx->tex0.use_alpha)
                 info.tex_color.a = info.vtx_color.a;
+            else
+                info.tex_color.a = info.srctex_color.a;
 
             if (info.tex_color.r > 0xFF)
                 info.tex_color.r = 0xFF;

--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -2451,11 +2451,14 @@ void GraphicsSynthesizerThread::calculate_LOD(TexLookupInfo &info)
 {
     double K = (current_ctx->tex1.K + 8.0) / 16.0;
     if (current_ctx->tex1.LOD_method == 0)
+    {
         info.LOD = ldexp(log2(1.0 / fabs(info.vtx_color.q)), current_ctx->tex1.L) + K;
+
+        if (!(current_ctx->tex1.filter_smaller & 0x1))
+            info.LOD = round(info.LOD + 0.5);
+    }
     else
         info.LOD = K;
-
-    info.LOD = round(info.LOD + 0.5);
 
     if (current_ctx->tex1.filter_smaller >= 2)
     {
@@ -2525,7 +2528,7 @@ void GraphicsSynthesizerThread::calculate_LOD(TexLookupInfo &info)
         info.tex_height = max((int)info.tex_height, 1);
     }
 }
-
+#define printf(fmt, ...)(0)
 void GraphicsSynthesizerThread::tex_lookup(int16_t u, int16_t v, TexLookupInfo& info)
 {
     bool bilinear_filter = false;

--- a/src/core/gsthread.hpp
+++ b/src/core/gsthread.hpp
@@ -337,7 +337,7 @@ class GraphicsSynthesizerThread
         int16_t multiply_tex_color(int16_t tex_color, int16_t frag_color);
         void calculate_LOD(TexLookupInfo& info);
         void tex_lookup(int16_t u, int16_t v, TexLookupInfo& info);
-        void tex_lookup_int(int16_t u, int16_t v, TexLookupInfo& info);
+        void tex_lookup_int(int16_t u, int16_t v, TexLookupInfo& info, bool forced_lookup = false);
         void clut_lookup(uint8_t entry, RGBAQ_REG& tex_color);
         void clut_CSM2_lookup(uint8_t entry, RGBAQ_REG& tex_color);
         void reload_clut(const GSContext& context);

--- a/src/core/gsthread.hpp
+++ b/src/core/gsthread.hpp
@@ -218,6 +218,8 @@ struct TexLookupInfo
     uint16_t tex_width, tex_height;
 
     uint8_t fog;
+    bool new_lookup;
+    int16_t lastu, lastv;
 };
 
 class GraphicsSynthesizerThread
@@ -334,7 +336,7 @@ class GraphicsSynthesizerThread
         uint8_t get_16bit_alpha(uint16_t color);
         void calculate_LOD(TexLookupInfo& info);
         void tex_lookup(int16_t u, int16_t v, TexLookupInfo& info);
-        void tex_lookup_int(int16_t u, int16_t v, TexLookupInfo& info);
+        bool tex_lookup_int(int16_t u, int16_t v, TexLookupInfo& info, bool forced_lookup = false);
         void clut_lookup(uint8_t entry, RGBAQ_REG& tex_color);
         void clut_CSM2_lookup(uint8_t entry, RGBAQ_REG& tex_color);
         void reload_clut(const GSContext& context);

--- a/src/core/gsthread.hpp
+++ b/src/core/gsthread.hpp
@@ -336,7 +336,7 @@ class GraphicsSynthesizerThread
         uint8_t get_16bit_alpha(uint16_t color);
         void calculate_LOD(TexLookupInfo& info);
         void tex_lookup(int16_t u, int16_t v, TexLookupInfo& info);
-        void tex_lookup_int(int16_t u, int16_t v, TexLookupInfo& info, bool forced_lookup = false);
+        void tex_lookup_int(int16_t u, int16_t v, TexLookupInfo& info);
         void clut_lookup(uint8_t entry, RGBAQ_REG& tex_color);
         void clut_CSM2_lookup(uint8_t entry, RGBAQ_REG& tex_color);
         void reload_clut(const GSContext& context);

--- a/src/core/gsthread.hpp
+++ b/src/core/gsthread.hpp
@@ -209,7 +209,7 @@ struct Vertex
 struct TexLookupInfo
 {
     //int32_t u, v;
-    RGBAQ_REG vtx_color, tex_color;
+    RGBAQ_REG vtx_color, tex_color, srctex_color;
     float LOD;
     int mipmap_level;
 
@@ -336,7 +336,7 @@ class GraphicsSynthesizerThread
         uint8_t get_16bit_alpha(uint16_t color);
         void calculate_LOD(TexLookupInfo& info);
         void tex_lookup(int16_t u, int16_t v, TexLookupInfo& info);
-        bool tex_lookup_int(int16_t u, int16_t v, TexLookupInfo& info, bool forced_lookup = false);
+        void tex_lookup_int(int16_t u, int16_t v, TexLookupInfo& info, bool forced_lookup = false);
         void clut_lookup(uint8_t entry, RGBAQ_REG& tex_color);
         void clut_CSM2_lookup(uint8_t entry, RGBAQ_REG& tex_color);
         void reload_clut(const GSContext& context);

--- a/src/core/gsthread.hpp
+++ b/src/core/gsthread.hpp
@@ -334,6 +334,7 @@ class GraphicsSynthesizerThread
         void write_PSMCT4_block(uint32_t base, uint32_t width, uint32_t x, uint32_t y, uint8_t value);
 
         uint8_t get_16bit_alpha(uint16_t color);
+        int16_t multiply_tex_color(int16_t tex_color, int16_t frag_color);
         void calculate_LOD(TexLookupInfo& info);
         void tex_lookup(int16_t u, int16_t v, TexLookupInfo& info);
         void tex_lookup_int(int16_t u, int16_t v, TexLookupInfo& info);

--- a/src/core/iop/iop_timers.cpp
+++ b/src/core/iop/iop_timers.cpp
@@ -40,16 +40,23 @@ void IOPTiming::update_timers()
 {
     for (int i = 0; i < 6; i++)
     {
+        if (!timers[i].control.started)
+        {
+            timers[i].clocks = 0;
+            timers[i].last_update = cycle_count;
+            continue;
+        }
+
         uint64_t delta = cycle_count - timers[i].last_update;
         uint64_t counter_delta = delta / timers[i].clock_scale;
 
         //Keep track of cycles between counter updates
         if (timers[i].clock_scale > 1)
         {
-            uint64_t clock_delta = delta & (timers[i].clock_scale - 1);
+            uint64_t clock_delta = delta % timers[i].clock_scale;
 
             timers[i].clocks += clock_delta;
-            if (timers[i].clocks > timers[i].clock_scale)
+            if (timers[i].clocks >= timers[i].clock_scale)
             {
                 timers[i].clocks -= timers[i].clock_scale;
                 counter_delta++;
@@ -57,6 +64,7 @@ void IOPTiming::update_timers()
         }
 
         timers[i].counter += counter_delta;
+        uint64_t overflow = (i > 2) ? 0x100000000UL : 0x10000;
 
         //Target check
         if ((timers[i].counter - counter_delta) < timers[i].target && timers[i].counter >= timers[i].target)
@@ -66,16 +74,23 @@ void IOPTiming::update_timers()
             {
                 IRQ_test(i, false);
                 if (timers[i].control.zero_return)
+                {
                     timers[i].counter -= timers[i].target;
+                    timers[i].target &= overflow - 1;
+                }
+                else
+                    timers[i].target |= overflow;
             }
         }
 
         //Overflow check
-        uint32_t overflow = (i > 2) ? 0xFFFFFFFF : 0xFFFF;
-        if (timers[i].counter > overflow)
+        if (timers[i].counter >= overflow)
         {
-            while (timers[i].counter > overflow)
+            while (timers[i].counter >= overflow)
                 timers[i].counter -= overflow;
+
+            timers[i].target &= overflow-1;
+
             if (timers[i].control.overflow_interrupt_enabled)
             {
                 IRQ_test(i, true);
@@ -88,13 +103,16 @@ void IOPTiming::update_timers()
 
 void IOPTiming::reschedule()
 {
-    uint64_t next_event_delta = 0x100000;
+    uint64_t next_event_delta = 0x100000000UL;
     for (int i = 0; i < 6; i++)
     {
+        if (!timers[i].control.started)
+            continue;
+
         uint64_t overflow_mask = (i > 2) ? 0x100000000UL : 0x10000;
         uint64_t overflow_delta = ((overflow_mask - timers[i].counter) * timers[i].clock_scale) - timers[i].clocks;
 
-        uint64_t target_delta = 0xFFFFFFFF;
+        uint64_t target_delta = overflow_mask;
 
         //Don't calculate target delta if the counter is higher, as overflow delta will be reached next
         if (timers[i].target > timers[i].counter)
@@ -108,47 +126,11 @@ void IOPTiming::reschedule()
 
 void IOPTiming::run(int cycles)
 {
-    /*while (cycles--)
-    {
-        for (int i = 0; i < 6; i++)
-        {
-            timers[i].clocks++;
-            if (timers[i].clocks >= timers[i].clock_scale)
-                count_up(i, timers[i].clock_scale);
-        }
-    }*/
     cycle_count += cycles;
     if (cycle_count >= next_event)
     {
         update_timers();
         reschedule();
-    }
-}
-
-void IOPTiming::count_up(int index, int cycles_per_count)
-{
-    timers[index].clocks -= cycles_per_count;
-    timers[index].counter++;
-    if (timers[index].counter == timers[index].target)
-    {
-        timers[index].control.compare_interrupt = true;
-        if (timers[index].control.compare_interrupt_enabled)
-        {
-            IRQ_test(index, false);
-            if (timers[index].control.zero_return)
-                timers[index].counter = 0;
-        }
-    }
-
-    //Overflow check
-    uint32_t overflow = (index > 2) ? 0xFFFFFFFF : 0xFFFF;
-    if (timers[index].counter > overflow)
-    {
-        timers[index].counter -= overflow;
-        if (timers[index].control.overflow_interrupt_enabled)
-        {
-            IRQ_test(index, true);
-        }
     }
 }
 
@@ -163,6 +145,11 @@ void IOPTiming::IRQ_test(int index, bool overflow)
             timers[index].control.overflow_interrupt = true;
         else
             timers[index].control.compare_interrupt = true;
+    }
+    else
+    {
+        if (!timers[index].control.repeat_int)
+            return;
     }
 
     if (timers[index].control.toggle_int)
@@ -211,19 +198,32 @@ uint16_t IOPTiming::read_control(int index)
 
 void IOPTiming::write_counter(int index, uint32_t value)
 {
+    uint64_t target_overflow = (index > 2) ? 0xFFFFFFFF : 0xFFFF;
+
     update_timers();
     timers[index].counter = value;
+    timers[index].clocks = 0;
+
+    if (timers[index].counter < (timers[index].target & target_overflow))
+        timers[index].target &= target_overflow;
+
     printf("[IOP Timing] Write timer %d counter: $%08X\n", index, value);
     reschedule();
 }
 
 void IOPTiming::write_control(int index, uint16_t value)
 {
-    update_timers();
     printf("[IOP Timing] Write timer %d control $%04X\n", index, value);
+
+    update_timers();
     timers[index].control.use_gate = value & 0x1;
     if (timers[index].control.use_gate)
+    {
         Errors::die("IOPTiming timer %d control.use_gate is true", index);
+        timers[index].control.started = false;
+    }
+    else
+        timers[index].control.started = true;
     timers[index].control.gate_mode = (value >> 1) & 0x3;
     timers[index].control.zero_return = value & (1 << 3);
     timers[index].control.compare_interrupt_enabled = value & (1 << 4);
@@ -236,8 +236,6 @@ void IOPTiming::write_control(int index, uint16_t value)
         timers[index].control.prescale = (value >> 9) & 0x1;
     else
         timers[index].control.prescale = (value >> 13) & 0x3;
-
-    timers[index].counter = 0;
 
     uint32_t clock_scale;
 
@@ -286,18 +284,26 @@ void IOPTiming::write_control(int index, uint16_t value)
             break;
     }
 
-    if (clock_scale == 1)
-        timers[index].clocks = 0;
+    timers[index].counter = 0;
+    timers[index].clocks = 0;
+    timers[index].target &= (index > 2) ? 0xFFFFFFFF : 0xFFFF;
 
     reschedule();
 }
 
 void IOPTiming::write_target(int index, uint32_t value)
 {
+    uint64_t target_overflow = (index > 2) ? 0x100000000UL : 0x10000;
+
     update_timers();
     printf("[IOP Timing] Write timer %d target $%08X\n", index, value);
     timers[index].target = value;
+
+    if (timers[index].target < timers[index].counter)
+        timers[index].target |= target_overflow;
+
     if (!timers[index].control.toggle_int)
         timers[index].control.int_enable = true;
+
     reschedule();
 }

--- a/src/core/iop/iop_timers.hpp
+++ b/src/core/iop/iop_timers.hpp
@@ -17,13 +17,14 @@ struct IOP_Timer_Control
     uint8_t prescale;
     bool compare_interrupt;
     bool overflow_interrupt;
+    bool started;
 };
 
 struct IOP_Timer
 {
     uint64_t counter;
     IOP_Timer_Control control;
-    uint32_t target;
+    uint64_t target;
     uint32_t clocks;
     uint64_t last_update;
 
@@ -49,7 +50,6 @@ class IOPTiming
         IOPTiming(Emulator* e);
 
         void reset();
-        void count_up(int index, int cycles_per_count);
         void run(int cycles);
         uint32_t read_counter(int index);
         uint16_t read_control(int index);

--- a/src/core/serialize.cpp
+++ b/src/core/serialize.cpp
@@ -4,7 +4,7 @@
 
 #define VER_MAJOR 0
 #define VER_MINOR 0
-#define VER_REV 25
+#define VER_REV 26
 
 using namespace std;
 


### PR DESCRIPTION
Fixed IOP timers not counting properly with external clock sources
Implemented IOP timers one shot
Fixed EE timer gated mode not starting on gate signal
Laid some groundwork for IOP timer gates
Removed an old unused timer functions
Fixed VU JIT bug causing crash when using whole program optimization
Fixed VIF0 bug where it didn't know about GIF so some of the FLUSH modes didn't work
Bump savestate version to handle new counter sizes
Optimized GS Texture Lookup to not do unnecessary lookups
Fixed a bug where magnification was being done when LOD = 0 instead of < 0
Added new "Release Optimized" profile for Visual Studio for extra performance