### PR TITLE
EE VTLB

### DIFF
--- a/src/core/ee/cop0.cpp
+++ b/src/core/ee/cop0.cpp
@@ -286,18 +286,10 @@ void Cop0::set_tlb(int index)
     real_virt >>= new_entry->page_shift;
     real_virt *= new_entry->page_size;
 
-    printf("[COP0] New TLB entry at %d\n", index);
-    printf("ASID: $%02X VPN2: $%08X SPR: %d\n", new_entry->asid, new_entry->vpn2, new_entry->is_scratchpad);
-    printf("Page size: %d Real virt: $%08X\n", new_entry->page_size, real_virt);
-
     for (int i = 0; i < 2; i++)
     {
         uint32_t real_phy = new_entry->pfn[i] >> new_entry->page_shift;
         real_phy *= new_entry->page_size;
-        printf("D: %d V: %d C: %d\n", new_entry->dirty[i],
-               new_entry->valid[i], new_entry->cache_mode[i]);
-        printf("PFN: $%08X Real phy: $%08X\n", new_entry->pfn[i], real_phy);
-        printf("\n");
     }
 
     map_tlb(new_entry);
@@ -407,8 +399,6 @@ void Cop0::map_tlb(TLB_Entry *entry)
     uint32_t odd_virt_page = ((real_vpn + 1) * entry->page_size) / 4096;
     uint32_t odd_virt_addr = odd_virt_page * 4096;
     uint32_t odd_phy_addr = (entry->pfn[1] >> entry->page_shift) * entry->page_size;
-
-    printf("Even phy: $%08X Odd phy: $%08X\n", even_phy_addr, odd_phy_addr);
 
     if (entry->is_scratchpad)
     {

--- a/src/core/ee/cop0.hpp
+++ b/src/core/ee/cop0.hpp
@@ -46,10 +46,11 @@ struct TLB_Entry
     uint8_t cache_mode[2];
     uint32_t pfn[2];
     bool is_scratchpad;
-    bool global[2];
+    bool global;
     uint8_t asid;
     uint32_t vpn2;
     uint32_t page_size;
+    uint32_t page_mask;
 
     uint8_t page_shift;
 };

--- a/src/core/ee/cop0.hpp
+++ b/src/core/ee/cop0.hpp
@@ -64,8 +64,12 @@ class Cop0
         uint8_t* BIOS;
         uint8_t* spr;
 
-        void unmap_tlb(uint8_t** map, TLB_Entry* entry);
-        void map_tlb(uint8_t** map, TLB_Entry* entry);
+        uint8_t** kernel_vtlb;
+        uint8_t** sup_vtlb;
+        uint8_t** user_vtlb;
+
+        void unmap_tlb(TLB_Entry* entry);
+        void map_tlb(TLB_Entry* entry);
 
         uint8_t* get_mem_pointer(uint32_t paddr);
     public:
@@ -76,10 +80,13 @@ class Cop0
         uint32_t EPC, ErrorEPC;
         uint32_t PCCR, PCR0, PCR1;
         Cop0(DMAC* dmac);
+        ~Cop0();
+
+        uint8_t** get_vtlb_map();
 
         void reset();
         void init_mem_pointers(uint8_t* RDRAM, uint8_t* BIOS, uint8_t* spr);
-        void init_tlb(uint8_t** map);
+        void init_tlb();
 
         uint32_t mfc(int index);
         void mtc(int index, uint32_t value);
@@ -91,7 +98,7 @@ class Cop0
 
         void count_up(int cycles);
 
-        void set_tlb(uint8_t** map, int index);
+        void set_tlb(int index);
 
         void load_state(std::ifstream &state);
         void save_state(std::ofstream& state);

--- a/src/core/ee/cop0.hpp
+++ b/src/core/ee/cop0.hpp
@@ -50,6 +50,8 @@ struct TLB_Entry
     uint8_t asid;
     uint32_t vpn2;
     uint32_t page_size;
+
+    uint8_t page_shift;
 };
 
 class DMAC;
@@ -58,6 +60,14 @@ class Cop0
 {
     private:
         DMAC* dmac;
+        uint8_t* RDRAM;
+        uint8_t* BIOS;
+        uint8_t* spr;
+
+        void unmap_tlb(uint8_t** map, TLB_Entry* entry);
+        void map_tlb(uint8_t** map, TLB_Entry* entry);
+
+        uint8_t* get_mem_pointer(uint32_t paddr);
     public:
         TLB_Entry tlb[48];
         uint32_t gpr[32];
@@ -68,6 +78,8 @@ class Cop0
         Cop0(DMAC* dmac);
 
         void reset();
+        void init_mem_pointers(uint8_t* RDRAM, uint8_t* BIOS, uint8_t* spr);
+        void init_tlb(uint8_t** map);
 
         uint32_t mfc(int index);
         void mtc(int index, uint32_t value);
@@ -79,7 +91,7 @@ class Cop0
 
         void count_up(int cycles);
 
-        void set_tlb(int index);
+        void set_tlb(uint8_t** map, int index);
 
         void load_state(std::ifstream &state);
         void save_state(std::ofstream& state);

--- a/src/core/ee/cop0.hpp
+++ b/src/core/ee/cop0.hpp
@@ -3,6 +3,14 @@
 #include <cstdint>
 #include <fstream>
 
+enum CACHE_MODE
+{
+    UNCACHED = 2,
+    CACHED = 3,
+    UCAB = 7,
+    SPR = 8
+};
+
 enum COP0_REG
 {
     STATUS = 12,
@@ -55,6 +63,11 @@ struct TLB_Entry
     uint8_t page_shift;
 };
 
+struct VTLB_Info
+{
+    uint8_t cache_mode;
+};
+
 class DMAC;
 
 class Cop0
@@ -68,6 +81,8 @@ class Cop0
         uint8_t** kernel_vtlb;
         uint8_t** sup_vtlb;
         uint8_t** user_vtlb;
+
+        VTLB_Info* vtlb_info;
 
         void unmap_tlb(TLB_Entry* entry);
         void map_tlb(TLB_Entry* entry);
@@ -84,6 +99,8 @@ class Cop0
         ~Cop0();
 
         uint8_t** get_vtlb_map();
+
+        bool is_cached(uint32_t address);
 
         void reset();
         void init_mem_pointers(uint8_t* RDRAM, uint8_t* BIOS, uint8_t* spr);
@@ -104,6 +121,11 @@ class Cop0
         void load_state(std::ifstream &state);
         void save_state(std::ofstream& state);
 };
+
+inline bool Cop0::is_cached(uint32_t address)
+{
+    return vtlb_info[address / 4096].cache_mode == CACHE_MODE::CACHED;
+}
 
 inline bool Cop0::int_enabled()
 {

--- a/src/core/ee/cop0.hpp
+++ b/src/core/ee/cop0.hpp
@@ -39,6 +39,19 @@ struct COP0_CAUSE
     bool bd;
 };
 
+struct TLB_Entry
+{
+    bool valid[2];
+    bool dirty[2];
+    uint8_t cache_mode[2];
+    uint32_t pfn[2];
+    bool is_scratchpad;
+    bool global[2];
+    uint8_t asid;
+    uint32_t vpn2;
+    uint32_t page_size;
+};
+
 class DMAC;
 
 class Cop0
@@ -46,6 +59,7 @@ class Cop0
     private:
         DMAC* dmac;
     public:
+        TLB_Entry tlb[48];
         uint32_t gpr[32];
         COP0_STATUS status;
         COP0_CAUSE cause;
@@ -64,6 +78,8 @@ class Cop0
         bool int_pending();
 
         void count_up(int cycles);
+
+        void set_tlb(int index);
 
         void load_state(std::ifstream &state);
         void save_state(std::ofstream& state);

--- a/src/core/ee/dmac.cpp
+++ b/src/core/ee/dmac.cpp
@@ -393,11 +393,10 @@ void DMAC::process_SIF0(int cycles)
         {
             if (sif->get_SIF0_size() >= 4)
             {
+                uint128_t quad;
                 for (int i = 0; i < 4; i++)
-                {
-                    uint32_t word = sif->read_SIF0();
-                    e->write32(channels[SIF0].address + (i * 4), word);
-                }
+                    quad._u32[i] = sif->read_SIF0();
+                store128(channels[SIF0].address, quad);
                 advance_dest_dma(SIF0);
             }
             else

--- a/src/core/ee/emotion.cpp
+++ b/src/core/ee/emotion.cpp
@@ -129,6 +129,9 @@ int EmotionEngine::run(int cycles)
             uint32_t instruction = read_instr(PC);
             uint32_t lastPC = PC;
 
+            if (PC == 0x80005184)
+                can_disassemble = true;
+
             if (can_disassemble)
             {
                 std::string disasm = EmotionDisasm::disasm_instr(instruction, PC);
@@ -853,6 +856,12 @@ void EmotionEngine::set_int1_signal(bool value)
     cp0->cause.int1_pending = value;
     if (value)
         printf("[EE] Set INT1\n");
+}
+
+void EmotionEngine::tlbwi()
+{
+    int index = cp0->gpr[0];
+    cp0->set_tlb(index);
 }
 
 void EmotionEngine::eret()

--- a/src/core/ee/emotion.cpp
+++ b/src/core/ee/emotion.cpp
@@ -135,6 +135,9 @@ int EmotionEngine::run(int cycles)
             uint32_t instruction = read32(PC);
             uint32_t lastPC = PC;
 
+            //if (PC == 0x165A84)
+                //can_disassemble = true;
+
             if (can_disassemble)
             {
                 std::string disasm = EmotionDisasm::disasm_instr(instruction, PC);
@@ -926,13 +929,13 @@ void EmotionEngine::eret()
 
 void EmotionEngine::ei()
 {
-    if (cp0->status.edi || cp0->status.mode == 0)
+    if (cp0->status.edi || cp0->status.mode == 0 || cp0->status.exception || cp0->status.error)
         cp0->status.master_int_enable = true;
 }
 
 void EmotionEngine::di()
 {
-    if (cp0->status.edi || cp0->status.mode == 0)
+    if (cp0->status.edi || cp0->status.mode == 0 || cp0->status.exception || cp0->status.error)
         cp0->status.master_int_enable = false;
 }
 

--- a/src/core/ee/emotion.cpp
+++ b/src/core/ee/emotion.cpp
@@ -132,7 +132,7 @@ int EmotionEngine::run(int cycles)
         {
             cycles_to_run--;
 
-            uint32_t instruction = read32(PC);
+            uint32_t instruction = read_instr(PC);
             uint32_t lastPC = PC;
 
             if (can_disassemble)
@@ -255,8 +255,7 @@ uint64_t EmotionEngine::get_SA()
 
 uint32_t EmotionEngine::read_instr(uint32_t address)
 {
-    bool uncached = address & 0x30000000;
-    if (!uncached)
+    if (cp0->is_cached(address))
     {
         int index = (address >> 6) & 0x7F;
         uint16_t tag = address >> 13;
@@ -303,12 +302,10 @@ uint32_t EmotionEngine::read_instr(uint32_t address)
         //Simulate reading from RDRAM
         //The nonsequential penalty (mentioned above) is 32 cycles for all data types, up to a quadword (128 bits).
         //However, the EE loads two instructions at once. Since we only load a word, we divide the cycles in half.
-        if ((address & 0x1FFFFFFF) < 0x02000000)
-            cycles_to_run -= 16;
-        if (address >= 0x30100000 && address <= 0x31FFFFFF)
-            address -= 0x10000000;
+        //if ((address & 0x1FFFFFFF) < 0x02000000)
+            //cycles_to_run -= 16;
     }
-    return e->read32(address & 0x1FFFFFFF);
+    return read32(address);
 }
 
 uint8_t EmotionEngine::read8(uint32_t address)

--- a/src/core/ee/emotion.hpp
+++ b/src/core/ee/emotion.hpp
@@ -39,6 +39,8 @@ class EmotionEngine
         VectorUnit* vu0;
         VectorUnit* vu1;
 
+        uint8_t** tlb_map;
+
         //Each register is 128-bit
         uint8_t gpr[32 * sizeof(uint64_t) * 2];
         uint64_t LO, HI, LO1, HI1;
@@ -62,9 +64,11 @@ class EmotionEngine
         void deci2call(uint32_t func, uint32_t param);
     public:
         EmotionEngine(Cop0* cp0, Cop1* fpu, Emulator* e, uint8_t* sp, VectorUnit* vu0, VectorUnit* vu1);
+        ~EmotionEngine();
         static const char* REG(int id);
         static const char* SYSCALL(int id);
         void reset();
+        void init_tlb(uint8_t* RDRAM, uint8_t* BIOS);
         int run(int cycles);
         uint64_t get_cycle_count();
         uint64_t get_cop2_last_cycle();

--- a/src/core/ee/emotion.hpp
+++ b/src/core/ee/emotion.hpp
@@ -145,6 +145,7 @@ class EmotionEngine
         void set_int1_signal(bool value);
 
         void tlbwi();
+        void tlbp();
         void eret();
         void ei();
         void di();

--- a/src/core/ee/emotion.hpp
+++ b/src/core/ee/emotion.hpp
@@ -62,7 +62,6 @@ class EmotionEngine
         void deci2call(uint32_t func, uint32_t param);
     public:
         EmotionEngine(Cop0* cp0, Cop1* fpu, Emulator* e, VectorUnit* vu0, VectorUnit* vu1);
-        ~EmotionEngine();
         static const char* REG(int id);
         static const char* SYSCALL(int id);
         void reset();

--- a/src/core/ee/emotion.hpp
+++ b/src/core/ee/emotion.hpp
@@ -143,6 +143,7 @@ class EmotionEngine
         void set_int0_signal(bool value);
         void set_int1_signal(bool value);
 
+        void tlbwi();
         void eret();
         void ei();
         void di();

--- a/src/core/ee/emotion.hpp
+++ b/src/core/ee/emotion.hpp
@@ -20,9 +20,8 @@ struct Deci2Handler
 
 struct EE_ICacheLine
 {
-    bool valid[2];
     bool lfu[2];
-    uint16_t tag[2];
+    uint32_t tag[2];
 };
 
 class EmotionEngine

--- a/src/core/ee/emotion.hpp
+++ b/src/core/ee/emotion.hpp
@@ -54,8 +54,6 @@ class EmotionEngine
         bool can_disassemble;
         int delay_slot;
 
-        uint8_t* scratchpad;
-
         Deci2Handler deci2handlers[128];
         int deci2size;
 
@@ -63,12 +61,12 @@ class EmotionEngine
         void handle_exception(uint32_t new_addr, uint8_t code);
         void deci2call(uint32_t func, uint32_t param);
     public:
-        EmotionEngine(Cop0* cp0, Cop1* fpu, Emulator* e, uint8_t* sp, VectorUnit* vu0, VectorUnit* vu1);
+        EmotionEngine(Cop0* cp0, Cop1* fpu, Emulator* e, VectorUnit* vu0, VectorUnit* vu1);
         ~EmotionEngine();
         static const char* REG(int id);
         static const char* SYSCALL(int id);
         void reset();
-        void init_tlb(uint8_t* RDRAM, uint8_t* BIOS);
+        void init_tlb();
         int run(int cycles);
         uint64_t get_cycle_count();
         uint64_t get_cop2_last_cycle();

--- a/src/core/ee/emotiondisasm.cpp
+++ b/src/core/ee/emotiondisasm.cpp
@@ -913,6 +913,8 @@ string disasm_cop(uint32_t instruction, uint32_t instr_addr)
             {
                 case 0x2:
                     return "tlbwi";
+                case 0x8:
+                    return "tlbp";
                 case 0x18:
                     return "eret";
                 case 0x38:

--- a/src/core/ee/emotioninterpreter.cpp
+++ b/src/core/ee/emotioninterpreter.cpp
@@ -853,6 +853,7 @@ void EmotionInterpreter::cop(EmotionEngine &cpu, uint32_t instruction)
             switch (op2)
             {
                 case 0x2:
+                    cpu.tlbwi();
                     break;
                 case 0x18:
                     cpu.eret();

--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -171,6 +171,14 @@ void Emulator::reset()
     add_iop_event(SPU_SAMPLE, &Emulator::gen_sound_sample, 768);
 }
 
+void Emulator::print_state()
+{
+    printf("---EE STATE\n");
+    cpu.print_state();
+    printf("---IOP STATE\n");
+    iop.print_state();
+}
+
 void Emulator::vblank_start()
 {
     VBLANK_sent = true;

--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -78,9 +78,17 @@ void Emulator::run()
 
     add_ee_event(VBLANK_START, &Emulator::vblank_start, VBLANK_START_CYCLES);
     add_ee_event(VBLANK_END, &Emulator::vblank_end, CYCLES_PER_FRAME);
+
+    //uint8_t old_finish = 0, new_finish = 0;
     
     while (!frame_ended)
     {
+        /*new_finish = RDRAM[0x2666EC];
+        if (new_finish != old_finish)
+        {
+            printf("Change finish: $%02X ($%02X)\n", new_finish, old_finish);
+            old_finish = new_finish;
+        }*/
         int ee_cycles = scheduler.calculate_run_cycles();
         int bus_cycles = scheduler.get_bus_run_cycles();
         int iop_cycles = scheduler.get_iop_run_cycles();

--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -78,17 +78,9 @@ void Emulator::run()
 
     add_ee_event(VBLANK_START, &Emulator::vblank_start, VBLANK_START_CYCLES);
     add_ee_event(VBLANK_END, &Emulator::vblank_end, CYCLES_PER_FRAME);
-
-    //uint8_t old_finish = 0, new_finish = 0;
     
     while (!frame_ended)
     {
-        /*new_finish = RDRAM[0x2666EC];
-        if (new_finish != old_finish)
-        {
-            printf("Change finish: $%02X ($%02X)\n", new_finish, old_finish);
-            old_finish = new_finish;
-        }*/
         int ee_cycles = scheduler.calculate_run_cycles();
         int bus_cycles = scheduler.get_bus_run_cycles();
         int iop_cycles = scheduler.get_iop_run_cycles();

--- a/src/core/emulator.hpp
+++ b/src/core/emulator.hpp
@@ -106,6 +106,7 @@ class Emulator
         ~Emulator();
         void run();
         void reset();
+        void print_state();
         void press_button(PAD_BUTTON button);
         void release_button(PAD_BUTTON button);
         void update_joystick(JOYSTICK joystick, JOYSTICK_AXIS axis, uint8_t val);

--- a/src/core/iop/iop.cpp
+++ b/src/core/iop/iop.cpp
@@ -254,8 +254,10 @@ uint32_t IOP::read_instr(uint32_t addr)
         if (!icache[index].valid || icache[index].tag != tag)
         {
             //Cache miss: load 4 words
-            cycles_to_run -= 16;
-            muldiv_delay = std::max(muldiv_delay - 16, 0);
+            //I don't know what the exact count should be. 16 (4 * 4) breaks Fatal Frame 2.
+            //Current theory is 4 cycles for the first load + 1 * 3 cycles for sequential loads
+            cycles_to_run -= 7;
+            muldiv_delay = std::max(muldiv_delay - 7, 0);
             icache[index].valid = true;
             icache[index].tag = tag;
         }
@@ -285,6 +287,7 @@ void IOP::write32(uint32_t addr, uint32_t value)
 {
     if (cop0.status.IsC)
     {
+        //printf("Clearing IOP cache...\n");
         icache[(addr >> 4) & 0xFF].valid = false;
         return;
     }

--- a/src/core/iop/iop.cpp
+++ b/src/core/iop/iop.cpp
@@ -102,6 +102,7 @@ void IOP::run(int cycles)
 
 void IOP::print_state()
 {
+    printf("pc:$%08X\n", PC);
     for (int i = 1; i < 32; i++)
     {
         printf("%s:$%08X", REG(i), get_gpr(i));
@@ -110,6 +111,7 @@ void IOP::print_state()
         else
             printf("\t");
     }
+    printf("lo:$%08X\thi:$%08X\n", LO, HI);
 }
 
 void IOP::set_disassembly(bool dis)

--- a/src/core/serialize.cpp
+++ b/src/core/serialize.cpp
@@ -4,7 +4,7 @@
 
 #define VER_MAJOR 0
 #define VER_MINOR 0
-#define VER_REV 26
+#define VER_REV 27
 
 using namespace std;
 
@@ -256,6 +256,11 @@ void Cop0::load_state(ifstream &state)
     state.read((char*)&PCCR, sizeof(PCCR));
     state.read((char*)&PCR0, sizeof(PCR0));
     state.read((char*)&PCR1, sizeof(PCR1));
+    state.read((char*)&tlb, sizeof(tlb));
+
+    //Repopulate VTLB
+    for (int i = 0; i < 48; i++)
+        map_tlb(&tlb[i]);
 }
 
 void Cop0::save_state(ofstream &state)
@@ -268,6 +273,7 @@ void Cop0::save_state(ofstream &state)
     state.write((char*)&PCCR, sizeof(PCCR));
     state.write((char*)&PCR0, sizeof(PCR0));
     state.write((char*)&PCR1, sizeof(PCR1));
+    state.write((char*)&tlb, sizeof(tlb));
 }
 
 void Cop1::load_state(ifstream &state)

--- a/src/qt/emuthread.cpp
+++ b/src/qt/emuthread.cpp
@@ -205,16 +205,18 @@ void EmuThread::run()
                 old_frametime = chrono::system_clock::now();
                 emit update_FPS((int)round(FPS));
             }
-            catch (non_fatal_error &e)
+            catch (non_fatal_error &error)
             {
-                printf("non_fatal emulation error occurred\n%s\n", e.what());
-                emit emu_non_fatal_error(QString(e.what()));
+                printf("non_fatal emulation error occurred\n%s\n", error.what());
+                emit emu_non_fatal_error(QString(error.what()));
                 pause(PAUSE_EVENT::MESSAGE_BOX);
             }
-            catch (Emulation_error &e)
+            catch (Emulation_error &error)
             {
-                printf("Fatal emulation error occurred, stopping execution\n%s\n", e.what());
-                emit emu_error(QString(e.what()));
+                e.print_state();
+                printf("Fatal emulation error occurred, stopping execution\n%s\n", error.what());
+                fflush(stdout);
+                emit emu_error(QString(error.what()));
                 pause(PAUSE_EVENT::GAME_NOT_LOADED);
             }
         }


### PR DESCRIPTION
This implements the EE's TLB/MMU using a paged-based system.

This provides a couple of benefits:

* Memory accesses are faster as a pointer to RAM can be accessed directly
* Any invalid accesses (such as writes to NULL) can be caught. Previously, only a subset of all invalid accesses were caught. The new addition makes debugging easier.
* A game/program may now modify the TLB mapping without crashing. However, TLB misses are not properly handled (they terminate emulation) and remapping the TLB many times might be a performance issue.

I also modified IOP icache timings due to problems with games such as Fatal Frame 2 no longer booting, and I slightly optimized the EE icache.