### PR TITLE
appveyor.yml: Fix artifacts not being deployed for Linux and disable test phase

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,6 +52,9 @@ build_script:
 
 after_build:
 - cmd: 7z a DobieStation.zip DobieStation/release/
+- sh: 7z a ../DobieStation.zip DobieStation
+
+test: off
 
 artifacts:
 - path: DobieStation.zip


### PR DESCRIPTION
Test phase is unused, so I disabled it.
Linux artifacts failed to deploy since no archive was created.

No idea if these builds work or not..