### PR TITLE
Fix incorrect cleanup on exit

### DIFF
--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -250,7 +250,7 @@ void GraphicsSynthesizerThread::exit()
         payload.no_payload = {0};
         
         send_message({ GSCommand::die_t, payload });
-        
+        wake_thread();
         thread.join();
     }
 }

--- a/src/qt/emuwindow.cpp
+++ b/src/qt/emuwindow.cpp
@@ -123,7 +123,7 @@ int EmuWindow::init(int argc, char** argv)
 
 EmuWindow::~EmuWindow()
 {
-	emu_thread.wait();
+    emu_thread.wait();
 }
 
 

--- a/src/qt/emuwindow.cpp
+++ b/src/qt/emuwindow.cpp
@@ -121,6 +121,12 @@ int EmuWindow::init(int argc, char** argv)
     return 0;
 }
 
+EmuWindow::~EmuWindow()
+{
+	emu_thread.wait();
+}
+
+
 int EmuWindow::load_exec(const char* file_name, bool skip_BIOS)
 {
     if (!load_bios())

--- a/src/qt/emuwindow.hpp
+++ b/src/qt/emuwindow.hpp
@@ -46,6 +46,8 @@ class EmuWindow : public QMainWindow
         void show_default_view();
     public:
         explicit EmuWindow(QWidget *parent = nullptr);
+        ~EmuWindow() final;
+
         int init(int argc, char** argv);
         int load_exec(const char* file_name, bool skip_BIOS);
 

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -16,5 +16,7 @@ int main(int argc, char** argv)
         return 1;
 
     a.exec();
+
+    delete window;
     return 0;
 }

--- a/src/qt/main.cpp
+++ b/src/qt/main.cpp
@@ -1,4 +1,5 @@
 #include <QApplication>
+#include <memory>
 #include "emuwindow.hpp"
 
 using namespace std;
@@ -10,13 +11,11 @@ int main(int argc, char** argv)
     QApplication::setOrganizationDomain("https://github.com/PSI-Rockin/DobieStation");
 
     QApplication a(argc, argv);
-    EmuWindow* window = new EmuWindow();
+    auto window = unique_ptr<EmuWindow>(new EmuWindow());
 
     if (window->init(argc, argv))
         return 1;
 
     a.exec();
-
-    delete window;
     return 0;
 }


### PR DESCRIPTION
EmuWindow was never being deleted. Its destructor was never called and the entire emulator was leaked.
After fixing this, some other problems with cleaning up threads were noticed:
GraphicsSynthesizerThread was never woken up when being told to exit, waiting infinitely for the thread to join.
EmuThread's destructor was called before the thread had finished, causing a Qt error and SIGABORT.