### PR TITLE
qt: update qpalette color set

### DIFF
--- a/src/qt/renderwidget.cpp
+++ b/src/qt/renderwidget.cpp
@@ -10,7 +10,7 @@ RenderWidget::RenderWidget(QWidget* parent)
     : QWidget(parent)
 {
     QPalette palette;
-    palette.setColor(QPalette::Background, Qt::black);
+    palette.setColor(QPalette::Window, Qt::black);
     setPalette(palette);
     setAutoFillBackground(true);
 }


### PR DESCRIPTION
Updates the `QPalette::Background` member to `QPalette::Window` as recommended by the docs.

fix #231 