### PR TITLE
Allow VU0 to access VU1 registers

### DIFF
--- a/src/core/ee/dmac.cpp
+++ b/src/core/ee/dmac.cpp
@@ -70,13 +70,13 @@ uint128_t DMAC::fetch128(uint32_t addr)
         }
         if (addr < 0x11008000)
         {
-            return vu0->read_data<uint128_t>(addr);
+            return vu0->read_mem<uint128_t>(addr);
         }
         if (addr < 0x1100C000)
         {
             return vu1->read_instr<uint128_t>(addr);
         }
-        return vu1->read_data<uint128_t>(addr);
+        return vu1->read_mem<uint128_t>(addr);
     }
     else
     {
@@ -101,7 +101,7 @@ void DMAC::store128(uint32_t addr, uint128_t data)
         }
         if (addr < 0x11008000)
         {
-            vu0->write_data<uint128_t>(addr, data);
+            vu0->write_mem<uint128_t>(addr, data);
             return;
         }
         if (addr < 0x1100C000)
@@ -109,7 +109,7 @@ void DMAC::store128(uint32_t addr, uint128_t data)
             vu1->write_instr<uint128_t>(addr, data);
             return;
         }
-        vu1->write_data<uint128_t>(addr, data);
+        vu1->write_mem<uint128_t>(addr, data);
         return;
     }
     else

--- a/src/core/ee/emotion.cpp
+++ b/src/core/ee/emotion.cpp
@@ -656,7 +656,7 @@ void EmotionEngine::ctc(int cop_id, int reg, int cop_reg, uint32_t instruction)
                 clear_interlock();
             }
             if (cop_reg == 31)
-                vu1->start_program(bark);
+                vu1->start_program(bark << 3);
             else
                 vu0->ctc(cop_reg, bark);
             break;

--- a/src/core/ee/vif.cpp
+++ b/src/core/ee/vif.cpp
@@ -478,7 +478,7 @@ void VectorInterface::handle_UNPACK_masking(uint128_t& quad)
                     break;
                 case 3:
                     //printf("[VIF] Write Protecting to position %d\n", i);
-                    quad._u32[i] = vu->read_data<uint32_t>(unpack.addr + (i * 4));
+                    quad._u32[i] = vu->read_mem<uint32_t>(unpack.addr + (i * 4));
                     break;
                 default:
                     //No masking, ignore
@@ -843,7 +843,7 @@ void VectorInterface::process_UNPACK_quad(uint128_t &quad)
 
     //printf("[VIF] Write data mem $%08X: $%08X_%08X_%08X_%08X\n", unpack.addr,
     //quad._u32[3], quad._u32[2], quad._u32[1], quad._u32[0]);
-    vu->write_data<uint128_t>(unpack.addr, quad);
+    vu->write_mem<uint128_t>(unpack.addr, quad);
     unpack.addr += 16;
     unpack.num -= 1;
     

--- a/src/core/ee/vu.cpp
+++ b/src/core/ee/vu.cpp
@@ -317,7 +317,6 @@ void VectorUnit::run(int cycles)
         update_DIV_EFU_pipes();
         int_branch_pipeline.update();
 
-
         if (XGKICK_stall)
             break;
 
@@ -325,7 +324,7 @@ void VectorUnit::run(int cycles)
         {
             if (XGKICK_delay)
                 XGKICK_delay--;
-            else if(gif->path_active(1))
+            else if (gif->path_active(1))
                 handle_XGKICK();
         }
 
@@ -365,7 +364,7 @@ void VectorUnit::run(int cycles)
         {
             if (!ebit_delay_slot)
             {
-                printf("[VU] Ended execution!\n");
+                printf("[VU%d] Ended execution!\n", id);
                 running = false;
                 finish_on = false;
                 flush_pipes();
@@ -562,6 +561,22 @@ uint32_t VectorUnit::read_reg(uint32_t addr)
     {
         switch (addr)
         {
+            case 0x300:
+                return status;
+            case 0x310:
+                return *MAC_flags;
+            case 0x320:
+                return *CLIP_flags;
+            case 0x340:
+                return R.u;
+            case 0x350:
+                return I.u;
+            case 0x360:
+                return Q.u;
+            case 0x370:
+                return P.u;
+            case 0x3A0:
+                return PC;
             default:
                 return 0;
         }
@@ -1868,7 +1883,7 @@ void VectorUnit::ilw(uint32_t instr)
         {
             uint32_t word = read_data<uint32_t>(addr + (i * 4));
             printf(" $%04X ($%02X, %d, %d)", word, _field, _it_, _is_);
-            set_int(_it_, word);
+            set_int(_it_, word & 0xFFFF);
             break;
         }
     }

--- a/src/core/ee/vu.cpp
+++ b/src/core/ee/vu.cpp
@@ -1866,7 +1866,7 @@ void VectorUnit::ilw(uint32_t instr)
     {
         if (_field & (1 << (3 - i)))
         {
-            uint32_t word = read_data<uint32_t>(addr);
+            uint32_t word = read_data<uint32_t>(addr + (i * 4));
             printf(" $%04X ($%02X, %d, %d)", word, _field, _it_, _is_);
             set_int(_it_, word);
             break;
@@ -1884,7 +1884,7 @@ void VectorUnit::ilwr(uint32_t instr)
     {
         if (_field & (1 << (3 - i)))
         {
-            uint32_t word = read_data<uint32_t>(addr);
+            uint32_t word = read_data<uint32_t>(addr + (i * 4));
             printf(" $%04X ($%02X, %d, %d)", word, _field, _it_, _is_);
             set_int(_it_, word & 0xFFFF);
             break;

--- a/src/core/ee/vu.cpp
+++ b/src/core/ee/vu.cpp
@@ -548,7 +548,7 @@ void VectorUnit::handle_XGKICK()
 //VU0 can access VU1 registers through the addresses (anded with 0x7FFF) 0x4000-0x4400
 uint32_t VectorUnit::read_reg(uint32_t addr)
 {
-    addr &= 0xFFF;
+    addr &= 0x3FF;
     if (addr < 0x0200)
         return get_gpr_u(addr / 0x10, (addr & 0xC) / 4);
     else if (addr < 0x0300)
@@ -570,7 +570,7 @@ uint32_t VectorUnit::read_reg(uint32_t addr)
 
 void VectorUnit::write_reg(uint32_t addr, uint32_t data)
 {
-    addr &= 0xFFF;
+    addr &= 0x3FF;
     if (addr < 0x0200)
         set_gpr_u(addr / 0x10, (addr & 0xC) / 4, data);
     else if (addr < 0x0300)

--- a/src/core/ee/vu.cpp
+++ b/src/core/ee/vu.cpp
@@ -593,6 +593,8 @@ void VectorUnit::write_reg(uint32_t addr, uint32_t data)
         if ((addr & 0xF) < 4)
             set_int((addr - 0x0200) / 0x10, data);
     }
+    else
+        printf("[VU0] Unrecognized write to VU1 register $%04X: $%08X\n", addr, data);
 }
 
 /**

--- a/src/core/ee/vu.hpp
+++ b/src/core/ee/vu.hpp
@@ -401,7 +401,7 @@ inline T VectorUnit::read_data(uint32_t addr)
 {
     if (id == 1)
         return *(T*)&data_mem.m[addr & 0x3FFF];
-    if (addr >= 0x4000 && addr < 0x4400)
+    if (addr & 0x4000)
         return other_vu->read_reg(addr);
     return *(T*)&data_mem.m[addr & 0xFFF];
 }
@@ -424,7 +424,7 @@ inline void VectorUnit::write_data(uint32_t addr, T data)
 {
     if (id == 1)
         *(T*)&data_mem.m[addr & 0x3FFF] = data;
-    else if (addr >= 0x4000 && addr < 0x4400)
+    else if (addr & 0x4000)
         other_vu->write_reg(addr, data);
     else
         *(T*)&data_mem.m[addr & 0xFFF] = data;

--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -516,11 +516,11 @@ uint32_t Emulator::read32(uint32_t address)
     if (address >= 0x11000000 && address < 0x11004000)
         return vu0.read_instr<uint32_t>(address);
     if (address >= 0x11004000 && address < 0x11008000)
-        return vu0.read_data<uint32_t>(address);
+        return vu0.read_mem<uint32_t>(address);
     if (address >= 0x11008000 && address < 0x1100C000)
         return vu1.read_instr<uint32_t>(address);
     if (address >= 0x1100C000 && address < 0x11010000)
-        return vu1.read_data<uint32_t>(address);
+        return vu1.read_mem<uint32_t>(address);
     switch (address)
     {
         case 0x10002000:
@@ -722,7 +722,7 @@ void Emulator::write32(uint32_t address, uint32_t value)
     }
     if (address >= 0x11004000 && address < 0x11008000)
     {
-        vu0.write_data<uint32_t>(address, value);
+        vu0.write_mem<uint32_t>(address, value);
         return;
     }
     if (address >= 0x11008000 && address < 0x1100C000)
@@ -732,7 +732,7 @@ void Emulator::write32(uint32_t address, uint32_t value)
     }
     if (address >= 0x1100C000 && address < 0x11010000)
     {
-        vu1.write_data<uint32_t>(address, value);
+        vu1.write_mem<uint32_t>(address, value);
         return;
     }
 
@@ -841,7 +841,7 @@ void Emulator::write64(uint32_t address, uint64_t value)
     }
     if (address >= 0x11004000 && address < 0x11008000)
     {
-        vu0.write_data<uint64_t>(address, value);
+        vu0.write_mem<uint64_t>(address, value);
         return;
     }
     if (address >= 0x11008000 && address < 0x1100C000)
@@ -851,7 +851,7 @@ void Emulator::write64(uint32_t address, uint64_t value)
     }
     if (address >= 0x1100C000 && address < 0x11010000)
     {
-        vu1.write_data<uint64_t>(address, value);
+        vu1.write_mem<uint64_t>(address, value);
         return;
     }
     Errors::print_warning("Unrecognized write64 at physical addr $%08X of $%08X_%08X\n", address, value >> 32, value & 0xFFFFFFFF);
@@ -868,7 +868,7 @@ void Emulator::write128(uint32_t address, uint128_t value)
         }
         if (address < 0x11008000)
         {
-            vu0.write_data<uint128_t>(address & 0xFFF, value);
+            vu0.write_mem<uint128_t>(address & 0xFFF, value);
             return;
         }
         if (address < 0x1100C000)
@@ -876,7 +876,7 @@ void Emulator::write128(uint32_t address, uint128_t value)
             vu1.write_instr<uint128_t>(address, value);
             return;
         }
-        vu1.write_data<uint128_t>(address, value);
+        vu1.write_mem<uint128_t>(address, value);
         return;
     }
     switch (address)

--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -34,8 +34,8 @@ Emulator::Emulator() :
     spu2(2, this, &iop_dma),
     vif0(nullptr, &vu0, &intc, &dmac, 0),
     vif1(&gif, &vu1, &intc, &dmac, 1),
-    vu0(0, this, &intc, &cpu),
-    vu1(1, this, &intc, &cpu),
+    vu0(0, this, &intc, &cpu, &vu1),
+    vu1(1, this, &intc, &cpu, &vu0),
     sif(&iop_dma, &dmac)
 {
     BIOS = nullptr;


### PR DESCRIPTION
VU0/COP2 can read/write VU1 registers through the range 0x4000-0x4400, which is also mirrored at 0xC000-0xC400.

Marvel Nemesis: Rise of the Imperfects relies on this so that VU0 can wait for VU1 to end before preparing a fresh batch of vertex data. This PR allows it to go past the loading screen before in-game, but unfortunately it is unplayable due to massive SPS and invalid data errors.