### PR TITLE
HLE OsdConfigParam

### DIFF
--- a/src/core/ee/emotion.cpp
+++ b/src/core/ee/emotion.cpp
@@ -113,6 +113,7 @@ void EmotionEngine::reset()
     //The solution is to HLE the syscalls used to access the config.
     //This allows us to set the default BIOS language to English. The settings can still be changed at full boot.
     //TODO: Read in system settings from NVM so that non-English languages can be used at fast boot.
+    //TODO: Expose language setting in the UI so that a default language can be selected even without NVM.
     osd_config_param.screenType = 0; //4:3
     osd_config_param.ps1drvConfig = 0; //???
     osd_config_param.spdifMode = 0; //Enabled

--- a/src/core/ee/emotion.cpp
+++ b/src/core/ee/emotion.cpp
@@ -107,6 +107,21 @@ void EmotionEngine::reset()
     wait_for_VU0 = false;
     delay_slot = 0;
 
+    //OsdConfigParam is used by certain games to detect language settings.
+    //This is not initialized until OSDSYS boots. Since fast boot skips this,
+    //games that rely on this will read zeroed out data (this usually manifests as Japanese).
+    //The solution is to HLE the syscalls used to access the config.
+    //This allows us to set the default BIOS language to English. The settings can still be changed at full boot.
+    //TODO: Read in system settings from NVM so that non-English languages can be used at fast boot.
+    osd_config_param.screenType = 0; //4:3
+    osd_config_param.ps1drvConfig = 0; //???
+    osd_config_param.spdifMode = 0; //Enabled
+    osd_config_param.timezoneOffset = 0;
+    osd_config_param.videoOutput = 0; //RGB
+    osd_config_param.japLanguage = 1; //Indicates not Japanese
+    osd_config_param.language = 1; //English
+    osd_config_param.version = 1; //Indicates normal kernel without extended language settings
+
     //Reset the cache
     for (int i = 0; i < 128; i++)
     {
@@ -839,8 +854,8 @@ void EmotionEngine::handle_exception(uint32_t new_addr, uint8_t code)
 void EmotionEngine::syscall_exception()
 {
     int op = get_gpr<int>(3);
-    //if (op != 0x7A)
-        //printf("[EE] SYSCALL: %s (id: $%02X) called at $%08X\n", SYSCALL(op), op, PC);
+    if (op != 0x7A)
+        printf("[EE] SYSCALL: %s (id: $%02X) called at $%08X\n", SYSCALL(op), op, PC);
 
     if (op == 0x64)
     {
@@ -850,6 +865,27 @@ void EmotionEngine::syscall_exception()
         //We have to wait until after we've left the block before we can erase blocks.
         if (a0 != 0 && a0 != 1)
             flush_jit_cache = true;
+    }
+
+    if (op == 0x4A)
+    {
+        //SetOsdConfigParam
+        uint32_t ptr = get_gpr<uint32_t>(4);
+        uint32_t value = read32(ptr);
+
+        memcpy(&osd_config_param, &value, 4);
+    }
+
+    if (op == 0x4B)
+    {
+        //GetOsdConfigParam
+        uint32_t ptr = get_gpr<uint32_t>(4);
+
+        uint32_t value;
+        memcpy(&value, &osd_config_param, 4);
+
+        write32(ptr, value);
+        return;
     }
 
     if (op == 0x7C)

--- a/src/core/ee/emotion.hpp
+++ b/src/core/ee/emotion.hpp
@@ -27,6 +27,28 @@ struct EE_ICacheLine
     uint32_t tag[2];
 };
 
+//Taken from PS2SDK
+struct EE_OsdConfigParam
+{
+    /** 0=enabled, 1=disabled */
+    /*00*/uint32_t spdifMode:1;
+        /** 0=4:3, 1=fullscreen, 2=16:9 */
+    /*01*/uint32_t screenType:2;
+        /** 0=rgb(scart), 1=component */
+    /*03*/uint32_t videoOutput:1;
+        /** 0=japanese, 1=english(non-japanese) */
+    /*04*/uint32_t japLanguage:1;
+        /** Playstation driver settings. */
+    /*05*/uint32_t ps1drvConfig:8;
+        /** 0 = early Japanese OSD, 1 = OSD2, 2 = OSD2 with extended languages.
+         * Early kernels cannot retain the value set in this field (Hence always 0). */
+    /*13*/uint32_t version:3;
+        /** LANGUAGE_??? value */
+    /*16*/uint32_t language:5;
+        /** timezone minutes offset from gmt */
+    /*21*/uint32_t timezoneOffset:11;
+};
+
 extern "C" uint8_t* exec_block_ee(EE_JIT64& jit, EmotionEngine& ee);
 
 class EmotionEngine
@@ -45,6 +67,8 @@ class EmotionEngine
         VectorUnit* vu1;
 
         uint8_t** tlb_map;
+
+        EE_OsdConfigParam osd_config_param;
 
         //Each register is 128-bit
         alignas(16) uint8_t gpr[32 * sizeof(uint64_t) * 2];


### PR DESCRIPTION
The config param is a setting used by certain games (Jak 2, Sonic Unleashed, etc) to retrieve the language. Fast boot on master doesn't initialize it, which causes those games to think that the BIOS language is set to Japanese. Furthermore, this causes Tomb Raider: Angel of Darkness and Guitar Hero to TLB miss on boot.

This PR initializes OsdConfigParam to English and fixes the crashes in the games mentioned above. Non-English speakers may still use full boot to initialize the BIOS language setting, and there are future plans to expose the default language in the UI.