### PR TITLE
Adjusted PCRTC stuff so games render in their proper resolutions. Cut…

### DIFF
--- a/src/core/gif.cpp
+++ b/src/core/gif.cpp
@@ -163,7 +163,9 @@ void GraphicsInterface::process_REGLIST(uint128_t data)
     {
         uint64_t reg_offset = (path[active_path].current_tag.reg_count - path[active_path].current_tag.regs_left) << 2;
         uint8_t reg = (path[active_path].current_tag.regs >> reg_offset) & 0xF;
-        gs->write64(reg, data._u64[i]);
+
+        if(reg != 0xE)
+            gs->write64(reg, data._u64[i]);
 
         path[active_path].current_tag.regs_left--;
         if (!path[active_path].current_tag.regs_left)
@@ -415,7 +417,7 @@ void GraphicsInterface::send_PATH3(uint128_t data)
     {
         //printf("Adding data to GIF FIFO (size: %d)\n", FIFO.size());
         FIFO.push(data);
-        if (FIFO.size() > 8)
+        if (FIFO.size() > 15)
             dmac->clear_DMA_request(GIF);
     }
 }

--- a/src/core/gif.cpp
+++ b/src/core/gif.cpp
@@ -164,6 +164,7 @@ void GraphicsInterface::process_REGLIST(uint128_t data)
         uint64_t reg_offset = (path[active_path].current_tag.reg_count - path[active_path].current_tag.regs_left) << 2;
         uint8_t reg = (path[active_path].current_tag.regs >> reg_offset) & 0xF;
 
+        //A+D is a NOP in REGLIST mode
         if(reg != 0xE)
             gs->write64(reg, data._u64[i]);
 
@@ -417,6 +418,9 @@ void GraphicsInterface::send_PATH3(uint128_t data)
     {
         //printf("Adding data to GIF FIFO (size: %d)\n", FIFO.size());
         FIFO.push(data);
+        //Need to check if the fifo is full (no less!)
+        //Some games (Wallace & Gromit) send 16QW with PATH3 masked
+        //If the dma execution is paused before then, the game will hang
         if (FIFO.size() > 15)
             dmac->clear_DMA_request(GIF);
     }

--- a/src/core/gsregisters.cpp
+++ b/src/core/gsregisters.cpp
@@ -294,21 +294,31 @@ void GS_REGISTERS::set_CRT(bool interlaced, int mode, bool frame_mode)
 
 void GS_REGISTERS::get_resolution(int &w, int &h)
 {
-    w = 640;
-    switch (CRT_mode)
+
+    if (DISPLAY1.magnify_x)
+        w = DISPLAY1.width / DISPLAY1.magnify_x;
+    else
+        w = 640;
+
+    /*switch (CRT_mode)
     {
-        case 0x2:
-            h = 448;
-            break;
-        case 0x3:
-            h = 512;
-            break;
-        case 0x1C:
-            h = 480;
-            break;
-        default:
-            h = 448;
-    }
+    case 0x2:
+        h = 448;
+        break;
+    case 0x3:
+        h = 512;
+        break;
+    case 0x1C:
+        h = 480;
+        break;
+    default:
+        h = 448;
+    }*/
+
+    h = DISPLAY1.height;
+    //TODO - Find out why some games double their height
+    if (h > w)
+        h /= 2;
 }
 
 void GS_REGISTERS::get_inner_resolution(int &w, int &h)
@@ -323,8 +333,14 @@ void GS_REGISTERS::get_inner_resolution(int &w, int &h)
     {
         current_display = DISPLAY2;
     }
-    w = current_display.width >> 2;
+    if (current_display.magnify_x)
+        w = current_display.width / current_display.magnify_x;
+    else
+        w = current_display.width >> 2;
     h = current_display.height;
+    //TODO - Find out why some games double their height
+    if (h > w)
+        h /= 2;
 }
 
 void GS_REGISTERS::set_VBLANK(bool is_VBLANK)

--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -3309,6 +3309,11 @@ void GraphicsSynthesizerThread::calculate_LOD(TexLookupInfo &info)
     else
         info.LOD = round(K);
 
+    info.tex_base = current_ctx->tex0.texture_base;
+    info.buffer_width = current_ctx->tex0.width;
+    info.tex_width = current_ctx->tex0.tex_width;
+    info.tex_height = current_ctx->tex0.tex_height;
+
     //Mipmapping is only enabled when the max MIP level is > 0 and filtering is set to a MIPMAP type
     if (current_ctx->tex1.max_MIP_level && current_ctx->tex1.filter_smaller >= 2)
     {
@@ -3320,10 +3325,6 @@ void GraphicsSynthesizerThread::calculate_LOD(TexLookupInfo &info)
 
         if (info.mipmap_level > 0)
         {
-            info.tex_base = current_ctx->tex0.texture_base;
-            info.buffer_width = current_ctx->tex0.width;
-            info.tex_width = current_ctx->tex0.tex_width;
-            info.tex_height = current_ctx->tex0.tex_height;
 
             if (current_ctx->tex1.MTBA && info.mipmap_level < 4)
             {

--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -601,6 +601,7 @@ void GraphicsSynthesizerThread::render_CRT(uint32_t* target)
         else
             width = reg.DISPLAY1.width >> 2;
         //TODO - Find out why some games double their height
+        //Examples are Pool Paradise, Silent Hill 2
         if (reg.DISPLAY1.height > width)
             height = reg.DISPLAY1.height / 2;
         else
@@ -3309,6 +3310,8 @@ void GraphicsSynthesizerThread::calculate_LOD(TexLookupInfo &info)
     else
         info.LOD = round(K);
 
+    //Need to reset the values here
+    //If the back of a triangle is MIP level 1 and the front is MIP level 0, it will have the wrong value
     info.tex_base = current_ctx->tex0.texture_base;
     info.buffer_width = current_ctx->tex0.width;
     info.tex_width = current_ctx->tex0.tex_width;

--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -1406,7 +1406,9 @@ void GraphicsSynthesizerThread::render_primitive()
 {
 #ifdef GS_JIT
     jit_draw_pixel_func = get_jitted_draw_pixel(draw_pixel_state);
-    jit_tex_lookup_func = get_jitted_tex_lookup(tex_lookup_state);
+    //No need to recompile tex_lookup if texture mapping is disabled. TEX0 can contain bad data
+    if(current_PRMODE->texture_mapping)
+        jit_tex_lookup_func = get_jitted_tex_lookup(tex_lookup_state);
 #endif
     switch (prim_type)
     {

--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -25,7 +25,7 @@ static SwizzleTable<32,128,128> page_PSMCT4;
 
 #define printf(fmt, ...)(0)
 
-#define GS_JIT
+//#define GS_JIT
 
 /**
   * ~ GS notes ~
@@ -1768,8 +1768,7 @@ void GraphicsSynthesizerThread::draw_pixel(int32_t x, int32_t y, uint32_t z, RGB
             //FBA performs "alpha correction" - MSB of alpha is always set when writing to frame buffer
             final_color |= current_ctx->FBA << 31;
         }
-        if (fb > 255 | fg > 255 | fr > 255)
-            Errors::die("fb %x fg %x fr %x\n", fb, fg, fr);
+
         final_color |= fb << 16;
         final_color |= fg << 8;
         final_color |= fr;

--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -1589,9 +1589,10 @@ void GraphicsSynthesizerThread::draw_pixel(int32_t x, int32_t y, uint32_t z, RGB
                 case 2: //ZB_ONLY - Only update z-buffer
                     update_frame = false;
                     break;
-                case 3: //RGB_ONLY - Same as FB_ONLY, but ignore alpha
+                case 3: //RGB_ONLY - Same as FB_ONLY, but ignore alpha unless the color format is not RGB32, then it's treated as FB_ONLY
                     update_z = false;
-                    update_alpha = false;
+                    if(current_ctx->tex0.format == 0)
+                        update_alpha = false;
                     break;
             }
         }

--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -25,7 +25,7 @@ static SwizzleTable<32,128,128> page_PSMCT4;
 
 #define printf(fmt, ...)(0)
 
-//#define GS_JIT
+#define GS_JIT
 
 /**
   * ~ GS notes ~
@@ -2965,6 +2965,11 @@ uint128_t GraphicsSynthesizerThread::local_to_host()
         case 0x1B:
             ppd = 8;
             break;
+        //PSMZ32
+        case 0x30:
+            ppd = 2;
+            break;
+        //PSMZ24
         case 0x31:
             ppd = 1; //Does it all in one go
             break;
@@ -3016,6 +3021,12 @@ uint128_t GraphicsSynthesizerThread::local_to_host()
                     data <<= 8;
                     data |= (uint64_t)((read_PSMCT32_block(BITBLTBUF.source_base, BITBLTBUF.source_width,
                         TRXPOS.int_source_x, TRXPOS.int_source_y) >> 24) & 0xFF) << (i * 8);
+                    pixels_transferred++;
+                    TRXPOS.int_source_x++;
+                    break;
+                case 0x30:
+                    data |= (uint64_t)(read_PSMCT32Z_block(BITBLTBUF.source_base, BITBLTBUF.source_width,
+                        TRXPOS.int_source_x, TRXPOS.int_source_y) & 0xFFFFFFFF) << (i * 32);
                     pixels_transferred++;
                     TRXPOS.int_source_x++;
                     break;
@@ -5088,6 +5099,7 @@ void GraphicsSynthesizerThread::load_state(ifstream *state)
     state->read((char*)&TRXDIR, sizeof(TRXDIR));
     state->read((char*)&BUSDIR, sizeof(BUSDIR));
     state->read((char*)&pixels_transferred, sizeof(pixels_transferred));
+    state->read((char*)&dither_mtx, sizeof(dither_mtx));
 
     state->read((char*)&PSMCT24_color, sizeof(PSMCT24_color));
     state->read((char*)&PSMCT24_unpacked_count, sizeof(PSMCT24_unpacked_count));
@@ -5136,6 +5148,7 @@ void GraphicsSynthesizerThread::save_state(ofstream *state)
     state->write((char*)&TRXDIR, sizeof(TRXDIR));
     state->write((char*)&BUSDIR, sizeof(BUSDIR));
     state->write((char*)&pixels_transferred, sizeof(pixels_transferred));
+    state->write((char*)&dither_mtx, sizeof(dither_mtx));
 
     state->write((char*)&PSMCT24_color, sizeof(PSMCT24_color));
     state->write((char*)&PSMCT24_unpacked_count, sizeof(PSMCT24_unpacked_count));

--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -1620,7 +1620,7 @@ void GraphicsSynthesizerThread::draw_pixel(int32_t x, int32_t y, uint32_t z, RGB
     if (update_frame)
     {
         //PABE - MSB of source alpha must be set to enable alpha blending
-        if (current_PRMODE->alpha_blend && (!PABE || (color.a & 0x80)) && current_ctx->tex0.format < 0x30)
+        if (current_PRMODE->alpha_blend && (!PABE || (color.a & 0x80)))
         {
             uint32_t r1, g1, b1;
             uint32_t r2, g2, b2;

--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -3736,7 +3736,7 @@ void GraphicsSynthesizerThread::clut_lookup(uint8_t entry, RGBAQ_REG &tex_color)
         case 0x00:
         case 0x01:
         {
-            uint32_t color = *(uint32_t*)&clut_cache[((clut_addr << 1) + (entry << 2)) & 0x7FF];
+            uint32_t color = *(uint32_t*)&clut_cache[((clut_addr << 1) + (entry << 2)) & 0x3FF];
             tex_color.r = color & 0xFF;
             tex_color.g = (color >> 8) & 0xFF;
             tex_color.b = (color >> 16) & 0xFF;

--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -25,7 +25,7 @@ static SwizzleTable<32,128,128> page_PSMCT4;
 
 #define printf(fmt, ...)(0)
 
-//#define GS_JIT
+#define GS_JIT
 
 /**
   * ~ GS notes ~

--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -1713,7 +1713,7 @@ void GraphicsSynthesizerThread::draw_pixel(int32_t x, int32_t y, uint32_t z, RGB
             uint8_t dither_amount = dither & 0x3;
             if (dither & 0x4)
             {
-                dither_amount + 1;
+                dither_amount += 1;
                 fb -= dither_amount;
                 fg -= dither_amount;
                 fr -= dither_amount;
@@ -1762,7 +1762,7 @@ void GraphicsSynthesizerThread::draw_pixel(int32_t x, int32_t y, uint32_t z, RGB
             uint8_t dither_amount = dither & 0x3;
             if (dither & 0x4)
             {
-                dither_amount + 1;
+                dither_amount += 1;
                 color.b -= dither_amount;
                 color.g -= dither_amount;
                 color.r -= dither_amount;


### PR DESCRIPTION
…s down on ugly pixels

Fixed bug in GIF FIFO which stopped games booting if PATH3 masking was enabled
Stopped REGLIST from sending A+D regs
Modified dithering on GS Interpreter and fixed a bug
Stop GS JIT crashing when an invalid TEX0 format is written
Fixed the address mask for 32bit CLUT lookups
