### PR TITLE
Backport CMake improvments from kojin's vk branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ demos
 CmakeSettings.json
 cmake-build-*/
 build/
+/*build/
 build-clang/
 build-DobieStation-*
 debug
@@ -18,3 +19,5 @@ Makefile*
 *.iso
 *.cso
 *.snp
+*_log.txt
+*.log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,39 +2,9 @@ cmake_minimum_required(VERSION 3.1)
 project(DobieStation
     VERSION 0.1.0)
 
-if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR
-    ${CMAKE_C_COMPILER_ID} STREQUAL "Clang" OR
-    ${CMAKE_C_COMPILER_ID} STREQUAL "AppleClang")
-
-    string(REPLACE "-O3" "-O2" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}")
-    set(DOBIE_FLAGS
-        -Wall -Wundef -Wsign-compare -Wconversion -Wstrict-aliasing -Wtype-limits
-
-        # These probably should be fixed instead of disabled,
-        # but doing so to keep the warning count more managable for now.
-        -Wno-reorder -Wno-unused-variable -Wno-unused-value
-
-        # Might be useful for debugging:
-        #-fomit-frame-pointer -fwrapv -fno-delete-null-pointer-checks -fno-strict-aliasing -fvisibility=hidden
-    )
-
-    if (${CMAKE_BUILD_TYPE} MATCHES "Debug" OR
-        ${CMAKE_C_COMPILER_ID} STREQUAL "AppleClang")
-
-        # Required on Debug configuration and all configurations on OSX, Dobie WILL crash otherwise.
-        set(DOBIE_FLAGS ${DOBIE_FLAGS} -fomit-frame-pointer)
-    endif()
-
-    if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU")
-        set(DOBIE_FLAGS ${DOBIE_FLAGS} -Wno-unused-but-set-variable) # GNU only warning
-    endif()
-
-    set(THREADS_PREFER_PTHREAD_FLAG ON) # -pthreads on GNU-like compilers
-
-elseif (MSVC)
-    set(DOBIE_FLAGS /W4) # Warning level 4
-
-endif()
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+string(REPLACE "-O3" "-O2" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}") # fix Release build
+set(THREADS_PREFER_PTHREAD_FLAG ON) # -pthreads on GNU-like compilers
 
 
 # Externals

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,6 @@ if (MSVC)
     set_property(DIRECTORY ${CMAKE_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT DobieQt)
 endif()
 
-install(TARGETS DobieQt DESTINATION bin)
-
 if (UNIX AND NOT APPLE)
     configure_file(
         ${CMAKE_CURRENT_SOURCE_DIR}/data/DobieStation.desktop.in

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
-project(DobieStation
-    VERSION 0.1.0)
+project(DobieStation)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
 string(REPLACE "-O3" "-O2" CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE}") # fix Release build

--- a/cmake/DobieHelpers.cmake
+++ b/cmake/DobieHelpers.cmake
@@ -20,7 +20,7 @@ function(dobie_cxx_compile_options TARGET)
     )
 
     target_compile_options(${TARGET} PRIVATE
-        $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:${DOBIE_GNU_FLAGS}>
+        $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>:${DOBIE_GNU_FLAGS}>
         $<$<CXX_COMPILER_ID:MSVC>:${DOBIE_MSVC_FLAGS}>)
 
     # Needed to avoid ruining global scope with Windows.h on win32

--- a/cmake/DobieHelpers.cmake
+++ b/cmake/DobieHelpers.cmake
@@ -1,0 +1,31 @@
+function(dobie_cxx_compile_options TARGET)
+
+    set(DOBIE_GNU_FLAGS
+        -Wall -Wundef -Wsign-compare -Wconversion -Wstrict-aliasing -Wtype-limits
+
+        # These probably should be fixed instead of disabled,
+        # but doing so to keep the warning count more managable for now.
+        -Wno-reorder -Wno-unused-variable -Wno-unused-value
+
+        # Required on Debug configuration and all configurations on OSX, Dobie WILL crash otherwise.
+        $<$<OR:$<CXX_COMPILER_ID:AppleClang>,$<CONFIG:Debug>>:-fomit-frame-pointer>
+
+        $<$<CXX_COMPILER_ID:GNU>:-Wno-unused-but-set-variable> # GNU only warning
+
+        # Might be useful for debugging:
+        #-fomit-frame-pointer -fwrapv -fno-delete-null-pointer-checks -fno-strict-aliasing -fvisibility=hidden
+    )
+    set(DOBIE_MSVC_FLAGS
+        /W4 # Warning level 4
+    )
+
+    target_compile_options(${TARGET} PRIVATE
+        $<$<CXX_COMPILER_ID:GNU,Clang,AppleClang>:${DOBIE_GNU_FLAGS}>
+        $<$<CXX_COMPILER_ID:MSVC>:${DOBIE_MSVC_FLAGS}>)
+
+    # Needed to avoid ruining global scope with Windows.h on win32
+    target_compile_definitions(${TARGET} PRIVATE
+        $<$<PLATFORM_ID:Windows>:WIN32_LEAN_AND_MEAN NOMINMAX>
+        $<$<CXX_COMPILER_ID:MSVC>:VC_EXTRALEAN>)
+
+endfunction()

--- a/data/DobieStation.desktop.in
+++ b/data/DobieStation.desktop.in
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Version=@PROJECT_VERSION@
+Version=1.1
 Name=DobieStation
 GenericName=PlayStation 2 Emulator
 Comment=A dog-themed PS2 emulator

--- a/ext/libdeflate/CMakeLists.txt
+++ b/ext/libdeflate/CMakeLists.txt
@@ -73,6 +73,7 @@ set(LIB_SRC
 add_library(${TARGET} STATIC ${LIB_SRC} ${LIB_HEADERS} ${COMMON_HEADERS})
 add_library(Ext::libdeflate ALIAS ${TARGET})
 set_target_properties(${TARGET} PROPERTIES PREFIX "")
+set_property(TARGET ${TARGET} PROPERTY FOLDER External)
 
 target_include_directories(${TARGET}
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,6 +1,8 @@
 set(TARGET Core)
 
 set(CMAKE_CXX_STANDARD 14)
+include(DobieHelpers)
+
 
 set(SOURCES
     emulator.cpp
@@ -160,19 +162,11 @@ set(HEADERS
     jitcommon/emitter64.hpp
     jitcommon/ir_block.hpp
     jitcommon/ir_instr.hpp
-    jitcommon/jitcache.hpp
-)
+    jitcommon/jitcache.hpp)
 
 add_library(${TARGET} ${SOURCES} ${HEADERS})
 add_library(Dobie::Core ALIAS ${TARGET})
 
+target_include_directories(${TARGET} PRIVATE ${CMAKE_SOURCE_DIR}/src)
 target_link_libraries(${TARGET} Ext::libdeflate Threads::Threads)
-target_compile_options(${TARGET} PRIVATE ${DOBIE_FLAGS})
-
-if (WIN32)
-    # Needed to avoid ruining global scope with Windows.h on win32
-    target_compile_definitions(${TARGET} PRIVATE WIN32_LEAN_AND_MEAN NOMINMAX)
-    if (MSVC)
-        target_compile_definitions(${TARGET} PRIVATE VC_EXTRALEAN)
-    endif()
-endif()
+dobie_cxx_compile_options(${TARGET})

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -40,3 +40,5 @@ target_include_directories(${TARGET} PRIVATE
     ${CMAKE_SOURCE_DIR}/src
     ${Qt5Gui_PRIVATE_INCLUDE_DIRS})
 target_link_libraries(${TARGET} Dobie::Core Qt5::Core Qt5::Widgets Qt5::Gui)
+
+install(TARGETS DobieQt RUNTIME DESTINATION bin)

--- a/src/qt/CMakeLists.txt
+++ b/src/qt/CMakeLists.txt
@@ -10,7 +10,7 @@ if(CMAKE_VERSION VERSION_LESS "3.7.0")
     set(CMAKE_INCLUDE_CURRENT_DIR ON)
 endif()
 
-find_package(Qt5 COMPONENTS Core Widgets REQUIRED)
+find_package(Qt5 COMPONENTS Core Widgets Gui REQUIRED)
 
 
 set(SOURCES
@@ -34,5 +34,9 @@ set(HEADERS
 
 add_executable(${TARGET} ${SOURCES} ${HEADERS})
 set_target_properties(${TARGET} PROPERTIES OUTPUT_NAME "DobieStation") # Output as "DobieStation" instead of "DobieQt"
-target_compile_options(${TARGET} PRIVATE ${DOBIE_FLAGS})
-target_link_libraries(${TARGET} Dobie::Core Qt5::Core Qt5::Widgets)
+
+dobie_cxx_compile_options(${TARGET})
+target_include_directories(${TARGET} PRIVATE
+    ${CMAKE_SOURCE_DIR}/src
+    ${Qt5Gui_PRIVATE_INCLUDE_DIRS})
+target_link_libraries(${TARGET} Dobie::Core Qt5::Core Qt5::Widgets Qt5::Gui)


### PR DESCRIPTION
Has some small improvements like:
- Bumping the C++ standard version to 14
- Refactored the flag setup into a macro function
- Fixes to maintain CMake 3.1 compatibility
- VS generator sticks libdeflate under an External folder
- Fix desktop file incorrectly using a (made up) project version rather than the *FreeDesktop specification* version, d'oh

~~Opening this as a draft for now because I haven't decided if I should keep the pre-merge history or squash it, opinions are welcome.~~ Squash it is.