### PR TITLE
gs: ignore draw where scissor is null

### DIFF
--- a/src/core/gscontext.hpp
+++ b/src/core/gscontext.hpp
@@ -62,6 +62,11 @@ struct MIPTBL
 struct SCISSOR
 {
     uint16_t x1, x2, y1, y2;
+
+    const bool empty() const noexcept
+    {
+        return x1 == x2 && y1 == y2;
+    }
 };
 
 struct ALPHA

--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -1405,6 +1405,10 @@ void GraphicsSynthesizerThread::vertex_kick(bool drawing_kick)
 
 void GraphicsSynthesizerThread::render_primitive()
 {
+    // ignore nop draw
+    if (current_ctx->scissor.empty())
+        return;
+
 #ifdef GS_JIT
     jit_draw_pixel_func = get_jitted_draw_pixel(draw_pixel_state);
     //No need to recompile tex_lookup if texture mapping is disabled. TEX0 can contain bad data


### PR DESCRIPTION
Some games like Armored Core Last Raven and Raw Danger will draw a sprite with the gs registers nulled.

We can ignore these draws and exit early.