### PR TITLE
gs: allow sprite rendering with reversed x/y

### DIFF
--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -2580,19 +2580,11 @@ void GraphicsSynthesizerThread::render_sprite()
 
     calculate_LOD(tex_info);
 
-    uint32_t zvalue = v2.z;
-    uint8_t fog = v2.fog;
-
-    if (v1.x > v2.x)
-    {
-        swap(v1, v2);
-    }
-
     //Automatic scissoring test
-    int32_t min_y = ((std::max(v1.y, (int32_t)current_ctx->scissor.y1) + 8) >> 4) << 4;
-    int32_t min_x = ((std::max(v1.x, (int32_t)current_ctx->scissor.x1) + 8) >> 4) << 4;
-    int32_t max_y = ((std::min(v2.y, (int32_t)current_ctx->scissor.y2 + 0x10) + 8) >> 4) << 4;
-    int32_t max_x = ((std::min(v2.x, (int32_t)current_ctx->scissor.x2 + 0x10) + 8) >> 4) << 4;
+    const int32_t min_y = ((std::max(std::min(v1.y, v2.y), (int32_t)current_ctx->scissor.y1) + 8) >> 4) << 4;
+    const int32_t min_x = ((std::max(std::min(v1.x, v2.x), (int32_t)current_ctx->scissor.x1) + 8) >> 4) << 4;
+    const int32_t max_y = ((std::min(std::max(v1.y, v2.y), (int32_t)current_ctx->scissor.y2 + 0x10) + 8) >> 4) << 4;
+    const int32_t max_x = ((std::min(std::max(v1.x, v2.x), (int32_t)current_ctx->scissor.x2 + 0x10) + 8) >> 4) << 4;
 
     printf("Coords: (%d, %d) (%d, %d)\n", min_x >> 4, min_y >> 4, max_x >> 4, max_y >> 4);
 
@@ -2617,7 +2609,7 @@ void GraphicsSynthesizerThread::render_sprite()
         {
             if (tmp_tex)
             {
-                tex_info.fog = fog;
+                tex_info.fog = v2.fog;
                 if (tmp_st)
                 {
                     pix_v = (pix_t * tex_info.tex_height) * 16.0;
@@ -2638,17 +2630,17 @@ void GraphicsSynthesizerThread::render_sprite()
                 }
 
 #ifdef GS_JIT
-                jit_draw_pixel_prologue(x, y, zvalue, tex_info.tex_color);
+                jit_draw_pixel_prologue(x, y, v2.z, tex_info.tex_color);
 #else
-                draw_pixel(x, y, zvalue, tex_info.tex_color);
+                draw_pixel(x, y, v2.z, tex_info.tex_color);
 #endif
             }
             else
             {
 #ifdef GS_JIT
-                jit_draw_pixel_prologue(x, y, zvalue, tex_info.vtx_color);
+                jit_draw_pixel_prologue(x, y, v2.z, tex_info.vtx_color);
 #else
-                draw_pixel(x, y, zvalue, tex_info.vtx_color);
+                draw_pixel(x, y, v2.z, tex_info.vtx_color);
 #endif
             }
             pix_s += pix_s_step;


### PR DESCRIPTION
Previous code swapped vertices to avoid x1 > x2
However, I don't see any actual issue with doing this as we'll just use a negative step

WRC will render with vertices like this:
v0: 0.0000, 0, 0
v1: 16.0000, 223.5000, 0
v2: 16.0000, 223.5000, 0
v3: 32.0000, 0, 0
v4: 32.0000, 0, 0
v5: 48.0000, 223.5000, 0
v6: 48.0000, 223.5000, 0
v7: 64.0000, 0, 0

which means swapping based on y will just result in that situation anyway.
instead correct the scissor