### PR TITLE
VIF, GIF and VU fixes

### DIFF
--- a/src/core/ee/vif.cpp
+++ b/src/core/ee/vif.cpp
@@ -43,6 +43,11 @@ void VectorInterface::reset()
     else
         mem_mask = 0xFF;
 
+    if (id)
+        fifo_size = 64;
+    else
+        fifo_size = 32;
+
     if(vu->get_id() == 1)
         VU_JIT::reset();
 }
@@ -81,7 +86,7 @@ void VectorInterface::update(int cycles)
     //This allows us to process one quadword per bus cycle
     if (fifo_reverse)
     {
-        if (FIFO.size() <= 60)
+        if (FIFO.size() <= (fifo_size - 4))
         {
             uint128_t fifo_data;
             while (cycles--)
@@ -145,7 +150,7 @@ void VectorInterface::update(int cycles)
             {
                 command_len--;
                 FIFO.pop();
-                if (FIFO.size() <= 32)
+                if (FIFO.size() <= (fifo_size - 4))
                     dmac->set_DMA_request(id);
             }
         }
@@ -862,7 +867,7 @@ void VectorInterface::process_UNPACK_quad(uint128_t &quad)
 bool VectorInterface::transfer_DMAtag(uint128_t tag)
 {
     //This should return false if the transfer stalls due to the FIFO filling up
-    if (FIFO.size() > 62)
+    if (FIFO.size() > (fifo_size - 2))
     {
         dmac->clear_DMA_request(id);
         return false;
@@ -875,7 +880,7 @@ bool VectorInterface::transfer_DMAtag(uint128_t tag)
 
 bool VectorInterface::feed_DMA(uint128_t quad)
 {
-    if (FIFO.size() > 60)
+    if (FIFO.size() > (fifo_size - 4))
     {
         dmac->clear_DMA_request(id);
         return false;

--- a/src/core/ee/vif.hpp
+++ b/src/core/ee/vif.hpp
@@ -97,7 +97,7 @@ class VectorInterface
         void MSCAL(uint32_t addr);
         void init_UNPACK(uint32_t value);
         bool is_filling_write();
-        void handle_UNPACK(uint32_t value);
+        void handle_UNPACK();
         void handle_UNPACK_masking(uint128_t& quad);
         void handle_UNPACK_mode(uint128_t& quad);
         void process_UNPACK_quad(uint128_t& quad);

--- a/src/core/ee/vif.hpp
+++ b/src/core/ee/vif.hpp
@@ -72,6 +72,7 @@ class VectorInterface
         bool flush_stall;
         uint32_t wait_cmd_value;
         uint16_t mem_mask;
+        uint32_t fifo_size;
 
         uint32_t buffer[4];
         int buffer_size;

--- a/src/core/ee/vu_jit64.cpp
+++ b/src/core/ee/vu_jit64.cpp
@@ -2065,7 +2065,7 @@ void VU_JIT64::eleng(VectorUnit &vu, IR::Instruction &instr)
     REG_64 source = alloc_sse_reg(vu, instr.get_source(), REG_STATE::READ);
     REG_64 temp = REG_64::XMM0;
 
-    clamp_vfreg(0xE, source);
+    clamp_vfreg(0x7, source);
 
     emitter.MOVAPS_REG(source, temp);
 
@@ -2085,7 +2085,7 @@ void VU_JIT64::erleng(VectorUnit &vu, IR::Instruction &instr)
     REG_64 temp = REG_64::XMM0;
     REG_64 temp2 = REG_64::XMM1;
 
-    clamp_vfreg(0xE, source);
+    clamp_vfreg(0x7, source);
 
     emitter.MOVAPS_REG(source, temp);
 
@@ -2145,7 +2145,7 @@ void VU_JIT64::rinit(VectorUnit &vu, IR::Instruction &instr)
     REG_64 source = alloc_sse_reg(vu, instr.get_source(), REG_STATE::READ);
     REG_64 temp = REG_64::XMM0;
 
-    clamp_vfreg(field, source);
+    clamp_vfreg(1 << field, source);
 
     //R = 0x3F800000 | (reg[field] & 0x007FFFFF)
     emitter.INSERTPS(field, 0, 0, source, temp);

--- a/src/core/gif.cpp
+++ b/src/core/gif.cpp
@@ -188,7 +188,6 @@ void GraphicsInterface::feed_GIF(uint128_t data)
     uint64_t data2 = data._u64[1];
     if (!path[active_path].current_tag.data_left)
     {
-        path_status[active_path] = path[active_path].current_tag.format;
         //Read new GIFtag
         path[active_path].current_tag.NLOOP = data1 & 0x7FFF;
         path[active_path].current_tag.end_of_packet = data1 & (1 << 15);
@@ -202,6 +201,7 @@ void GraphicsInterface::feed_GIF(uint128_t data)
         path[active_path].current_tag.regs_left = path[active_path].current_tag.reg_count;
         path[active_path].current_tag.data_left = path[active_path].current_tag.NLOOP;
 
+        path_status[active_path] = path[active_path].current_tag.format;
         //Q is initialized to 1.0 upon reading a GIFtag
         internal_Q = 1.0f;
 


### PR DESCRIPTION
GIF: Fix currently selected GIFTag format in activepath
VIF: Fix filling write unpacks which could happen at the end of a VIF transfer and need no data
VIF: Make sure VIF Stalls/interrupts only occur on the instruction after the MARK command if the stall was on the MARK
VU JIT: Correct a couple of incorrect clamps