### PR TITLE
gs-int: specify color format for z write when color write is z format

### DIFF
--- a/src/core/gscontext.cpp
+++ b/src/core/gscontext.cpp
@@ -182,7 +182,7 @@ void GSContext::set_frame(uint64_t value)
 void GSContext::set_zbuf(uint64_t value)
 {
     zbuf.base_pointer = (value & 0x1FF) * 2048 * 4;
-    zbuf.format = (value >> 24) & 0xF;
+    zbuf.format = ((value >> 24) & 0xF) | 0x30;
     zbuf.no_update = (value >> 32) & 0x1;
     printf("ZBUF: $%08X_%08X\n", value >> 32, value & 0xFFFFFFFF);
     printf("Base pointer: $%08X\n", zbuf.base_pointer);

--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -1470,6 +1470,12 @@ void GraphicsSynthesizerThread::render_primitive()
     if (current_ctx->scissor.empty())
         return;
 
+    // confirmed by hw test
+    // in the event that a z format is specified for FRAME
+    // the depth format will swap to a color format
+    if ((current_ctx->frame.format & 0x30) == 0x30)
+        current_ctx->zbuf.format &= ~0x30;
+
 #ifdef GS_JIT
     jit_draw_pixel_func = get_jitted_draw_pixel(draw_pixel_state);
     //No need to recompile tex_lookup if texture mapping is disabled. TEX0 can contain bad data
@@ -1510,14 +1516,25 @@ bool GraphicsSynthesizerThread::depth_test(int32_t x, int32_t y, uint32_t z)
             switch (current_ctx->zbuf.format)
             {
                 case 0x00:
-                    return z >= read_PSMCT32Z_block(base, width, x, y);
+                    return z >= read_PSMCT32_block(base, width, x, y);
                 case 0x01:
                     z = min(z, 0xFFFFFFU);
-                    return z >= (read_PSMCT32Z_block(base, width, x, y) & 0xFFFFFF);
+                    return z >= (read_PSMCT32_block(base, width, x, y) & 0xFFFFFF);
                 case 0x02:
                     z = min(z, 0xFFFFU);
-                    return z >= read_PSMCT16Z_block(base, width, x, y);
+                    return z >= read_PSMCT16_block(base, width, x, y);
                 case 0x0A:
+                    z = min(z, 0xFFFFU);
+                    return z >= read_PSMCT16S_block(base, width, x, y);
+                case 0x30:
+                    return z >= read_PSMCT32Z_block(base, width, x, y);
+                case 0x31:
+                    z = min(z, 0xFFFFFFU);
+                    return z >= (read_PSMCT32Z_block(base, width, x, y) & 0xFFFFFF);
+                case 0x32:
+                    z = min(z, 0xFFFFU);
+                    return z >= read_PSMCT16Z_block(base, width, x, y);
+                case 0x3A:
                     z = min(z, 0xFFFFU);
                     return z >= read_PSMCT16SZ_block(base, width, x, y);
                 default:
@@ -1528,14 +1545,25 @@ bool GraphicsSynthesizerThread::depth_test(int32_t x, int32_t y, uint32_t z)
             switch (current_ctx->zbuf.format)
             {
                 case 0x00:
-                    return z > read_PSMCT32Z_block(base, width, x, y);
+                    return z > read_PSMCT32_block(base, width, x, y);
                 case 0x01:
                     z = min(z, 0xFFFFFFU);
-                    return z > (read_PSMCT32Z_block(base, width, x, y) & 0xFFFFFF);
+                    return z > (read_PSMCT32_block(base, width, x, y) & 0xFFFFFF);
                 case 0x02:
                     z = min(z, 0xFFFFU);
-                    return z > read_PSMCT16Z_block(base, width, x, y);
+                    return z > read_PSMCT16_block(base, width, x, y);
                 case 0x0A:
+                    z = min(z, 0xFFFFU);
+                    return z > read_PSMCT16S_block(base, width, x, y);
+                case 0x30:
+                    return z > read_PSMCT32Z_block(base, width, x, y);
+                case 0x31:
+                    z = min(z, 0xFFFFFFU);
+                    return z > (read_PSMCT32Z_block(base, width, x, y) & 0xFFFFFF);
+                case 0x32:
+                    z = min(z, 0xFFFFU);
+                    return z > read_PSMCT16Z_block(base, width, x, y);
+                case 0x3A:
                     z = min(z, 0xFFFFU);
                     return z > read_PSMCT16SZ_block(base, width, x, y);
                 default:
@@ -1873,21 +1901,33 @@ void GraphicsSynthesizerThread::draw_pixel(int32_t x, int32_t y, uint32_t z, RGB
                 Errors::die("Unknown FRAME format (%x) write attempted", current_ctx->frame.format);
         }
     }
-    
+
     if (update_z)
     {
         switch (current_ctx->zbuf.format)
         {
             case 0x00:
-                write_PSMCT32Z_block(current_ctx->zbuf.base_pointer, current_ctx->frame.width, x, y, z);
+                write_PSMCT32_block(current_ctx->zbuf.base_pointer, current_ctx->frame.width, x, y, z);
                 break;
             case 0x01:
-                write_PSMCT24Z_block(current_ctx->zbuf.base_pointer, current_ctx->frame.width, x, y, z & 0xFFFFFF);
+                write_PSMCT24_block(current_ctx->zbuf.base_pointer, current_ctx->frame.width, x, y, z & 0xFFFFFF);
                 break;
             case 0x02:
-                write_PSMCT16Z_block(current_ctx->zbuf.base_pointer, current_ctx->frame.width, x, y, z & 0xFFFF);
+                write_PSMCT16_block(current_ctx->zbuf.base_pointer, current_ctx->frame.width, x, y, z & 0xFFFF);
                 break;
             case 0x0A:
+                write_PSMCT16S_block(current_ctx->zbuf.base_pointer, current_ctx->frame.width, x, y, z & 0xFFFF);
+                break;
+            case 0x30:
+                write_PSMCT32Z_block(current_ctx->zbuf.base_pointer, current_ctx->frame.width, x, y, z);
+                break;
+            case 0x31:
+                write_PSMCT24Z_block(current_ctx->zbuf.base_pointer, current_ctx->frame.width, x, y, z & 0xFFFFFF);
+                break;
+            case 0x32:
+                write_PSMCT16Z_block(current_ctx->zbuf.base_pointer, current_ctx->frame.width, x, y, z & 0xFFFF);
+                break;
+            case 0x3A:
                 write_PSMCT16SZ_block(current_ctx->zbuf.base_pointer, current_ctx->frame.width, x, y, z & 0xFFFF);
                 break;
         }

--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -4460,18 +4460,30 @@ void GraphicsSynthesizerThread::recompile_depth_test()
     switch (current_ctx->zbuf.format)
     {
         case 0x00:
+            jit_call_func(emitter_dp, (uint64_t)&addr_PSMCT32);
+            break;
+        case 0x01:
+            jit_call_func(emitter_dp, (uint64_t)&addr_PSMCT32);
+            break;
+        case 0x02:
+            jit_call_func(emitter_dp, (uint64_t)&addr_PSMCT16);
+            break;
+        case 0x0A:
+            jit_call_func(emitter_dp, (uint64_t)&addr_PSMCT16S);
+            break;
+        case 0x30:
             //PSMCT32Z
             jit_call_func(emitter_dp, (uint64_t)&addr_PSMCT32Z);
             break;
-        case 0x01:
+        case 0x31:
             //PSMCT24Z
             jit_call_func(emitter_dp, (uint64_t)&addr_PSMCT32Z);
             break;
-        case 0x02:
+        case 0x32:
             //PSMCT16Z
             jit_call_func(emitter_dp, (uint64_t)&addr_PSMCT16Z);
             break;
-        case 0x0A:
+        case 0x3A:
             //PSMCT16SZ
             jit_call_func(emitter_dp, (uint64_t)&addr_PSMCT16SZ);
             break;
@@ -4517,9 +4529,11 @@ void GraphicsSynthesizerThread::recompile_depth_test()
         switch (current_ctx->zbuf.format)
         {
             case 0x00:
+            case 0x30:
                 emitter_dp.MOV32_TO_MEM(R14, RCX);
                 break;
             case 0x01:
+            case 0x31:
                 emitter_dp.MOV32_FROM_MEM(RCX, RAX);
                 emitter_dp.AND32_EAX(0xFF000000);
                 emitter_dp.AND32_REG_IMM(0xFFFFFF, R14);


### PR DESCRIPTION
Confirmed by hw tests performed by water111.

The GS divides the block ordering of the z and color writes by format. This allows both writes to happen at the same time.
Color writes are performed on the left side of the page while z writes are performed on the right side.

However, in the event that a z format for frame is specified and both writes are enabled, the gs will swap the zbuf format for a color one.

Fix power drome.