### PR TITLE
Fix QtPlugins not being present in Devel and Release Optimized

### DIFF
--- a/DobieStation/qt.props
+++ b/DobieStation/qt.props
@@ -95,7 +95,12 @@
     <QtAllPlugins Include="$(QtPluginsDir)**\*$(QtLibSuffix).dll" />
     <QtPlugins Condition="'$(Configuration)'=='Debug'"
                Include="@(QtAllPlugins)" />
+    <QtPlugins Condition="'$(Configuration)'=='Devel'"
+               Include="@(QtAllPlugins)" />
     <QtPlugins Condition="'$(Configuration)'=='Release'"
+               Exclude="$(QtPluginsDir)**\*$(QtDebugSuffix).dll"
+               Include="@(QtAllPlugins)" />
+    <QtPlugins Condition="'$(Configuration)'=='Release Optimized'"
                Exclude="$(QtPluginsDir)**\*$(QtDebugSuffix).dll"
                Include="@(QtAllPlugins)" />
     <QtPluginsDest


### PR DESCRIPTION
Makes `Devel` And `Release Optimized` work from a clean build without copy/pasting stuff.