### PR TITLE
VIF and GIF Changes

### DIFF
--- a/src/core/ee/dmac.cpp
+++ b/src/core/ee/dmac.cpp
@@ -414,7 +414,10 @@ int DMAC::process_GIF()
                 advance_source_dma(GIF);
                 count++;
                 if (gif->path3_done())
-                    break;
+                {
+                    arbitrate();
+                    return count;
+                }
             }
             else
             {

--- a/src/core/ee/dmac.cpp
+++ b/src/core/ee/dmac.cpp
@@ -413,7 +413,7 @@ int DMAC::process_GIF()
                 gif->send_PATH3(fetch128(channels[GIF].address));
                 advance_source_dma(GIF);
                 count++;
-                if (gif->path3_done())
+                if (gif->path3_done() && !channels[GIF].tag_end)
                 {
                     arbitrate();
                     return count;

--- a/src/core/ee/vif.cpp
+++ b/src/core/ee/vif.cpp
@@ -124,8 +124,10 @@ void VectorInterface::update(int cycles)
         if (flush_stall)
         {
             int active_path = gif->get_active_path();
-            if (active_path == 1 || active_path == 2)
+            int path_queue = gif->get_path_queue();
+            if (active_path == 1 || active_path == 2 || (path_queue & (1<<1)) || (path_queue & (1<<2)))
                 return;
+
             flush_stall = false;
         }
 

--- a/src/core/ee/vif.hpp
+++ b/src/core/ee/vif.hpp
@@ -69,6 +69,7 @@ class VectorInterface
         bool fifo_reverse;
         
         bool wait_for_VU;
+        bool direct_wait;
         bool wait_for_PATH3;
         bool flush_stall;
         uint32_t wait_cmd_value;

--- a/src/core/ee/vif.hpp
+++ b/src/core/ee/vif.hpp
@@ -72,6 +72,7 @@ class VectorInterface
         bool direct_wait;
         bool wait_for_PATH3;
         bool flush_stall;
+        bool stall_condition_active;
         uint32_t wait_cmd_value;
         uint16_t mem_mask;
         uint32_t fifo_size;

--- a/src/core/gif.hpp
+++ b/src/core/gif.hpp
@@ -47,6 +47,7 @@ class GraphicsInterface
         bool intermittent_mode;
         bool intermittent_active;
         bool path3_dma_waiting;
+        bool gif_temporary_stop;
 
         float internal_Q;
 
@@ -65,11 +66,13 @@ class GraphicsInterface
         bool fifo_draining();
         void dma_waiting(bool dma_waiting);
         int get_active_path();
+        int get_path_queue();
         bool path_active(int index, bool canInterruptPath3);
         void resume_path3();
 
         uint32_t read_STAT();
         void write_MODE(uint32_t value);
+        void write_CTRL(uint32_t value);
 
         void request_PATH(int index, bool canInterruptPath3);
         void deactivate_PATH(int index);
@@ -97,13 +100,18 @@ inline int GraphicsInterface::get_active_path()
     return active_path;
 }
 
+inline int GraphicsInterface::get_path_queue()
+{
+    return path_queue;
+}
+
 inline bool GraphicsInterface::path_active(int index, bool canInterruptPath3)
 {
     if (index != 3 && canInterruptPath3)
     {
         interrupt_path3(index);
     }
-    return (active_path == index) && !gs->stalled();
+    return (active_path == index) && !gs->stalled() && !gif_temporary_stop;
 }
 
 inline void GraphicsInterface::resume_path3()

--- a/src/core/gif.hpp
+++ b/src/core/gif.hpp
@@ -76,7 +76,7 @@ class GraphicsInterface
 
         void request_PATH(int index, bool canInterruptPath3);
         void deactivate_PATH(int index);
-        void set_path3_vifmask(int value);
+        bool set_path3_vifmask(int value);
         bool path3_masked(int index);
         bool interrupt_path3(int index);
         bool path3_done();

--- a/src/core/gsregisters.cpp
+++ b/src/core/gsregisters.cpp
@@ -171,6 +171,8 @@ uint32_t GS_REGISTERS::read32_privileged(uint32_t addr)
             //printf("[GS_r] read32_privileged!: CSR = %04X\n", reg);
             return reg;
         }
+        case 0x1040:
+            return BUSDIR;
         case 0x1080:
             return SIGLBLID.sig_id;
         default:

--- a/src/core/serialize.cpp
+++ b/src/core/serialize.cpp
@@ -4,7 +4,7 @@
 
 #define VER_MAJOR 0
 #define VER_MINOR 0
-#define VER_REV 29
+#define VER_REV 30
 
 using namespace std;
 


### PR DESCRIPTION
*VIF: Fixed VIF Flush Stall when waiting on PATH1&2
*DMAC: Try to improve PATH3 Masking reliability at higher MAX_CYCLES
*GIF: Fill out most of GIF_STAT and correct FIFO size value
*GIF: Ignore PACKED writes to address 0x7F, since this doesn't exist
*GIF: Fix FINISH to only trigger when all transfers end
*GIF: Fix up unused intermitted check, can be used for testing
*GIF: Remove item from queue first, things have changed so it no longer needs to be last
*VIF: Fix stall conditions waiting for PATH1/2 and VU to be idle