### PR TITLE
Fix DMAC Stalls and IRQ's

### DIFF
--- a/src/core/ee/dmac.cpp
+++ b/src/core/ee/dmac.cpp
@@ -410,7 +410,8 @@ int DMAC::process_GIF()
                     printf("[DMAC] GIF DMA Stall at %x STADR = %x\n", channels[GIF].address, STADR);
                     interrupt_stat.channel_stat[DMA_STALL] = true;
                     int1_check();
-                    gif->deactivate_PATH(3);
+                    if(gif->path3_done())
+                        gif->deactivate_PATH(3);
                     channels[GIF].has_dma_stalled = true;
                 }
 

--- a/src/core/ee/dmac.cpp
+++ b/src/core/ee/dmac.cpp
@@ -290,9 +290,11 @@ int DMAC::process_VIF1()
                             printf("[DMAC] VIF1 DMA Stall at %x STADR = %x\n", channels[VIF1].address, STADR);
                             interrupt_stat.channel_stat[DMA_STALL] = true;
                             int1_check();
-                            arbitrate();
-                            break;
+                            channels[VIF1].has_dma_stalled = true;
                         }
+
+                        arbitrate();
+                        break;
                     }
                     channels[VIF1].has_dma_stalled = false;
                 }
@@ -416,10 +418,12 @@ int DMAC::process_GIF()
                         printf("[DMAC] GIF DMA Stall at %x STADR = %x\n", channels[GIF].address, STADR);
                         interrupt_stat.channel_stat[DMA_STALL] = true;
                         int1_check();
-                        arbitrate();
                         gif->deactivate_PATH(3);
-                        break;
+                        channels[GIF].has_dma_stalled = true;
                     }
+
+                    arbitrate();
+                    break;
                 }
                 channels[GIF].has_dma_stalled = false;
             }
@@ -699,9 +703,10 @@ int DMAC::process_SIF1()
                         printf("[DMAC] SIF1 DMA Stall at %x STADR = %x\n", channels[EE_SIF1].address, STADR);
                         interrupt_stat.channel_stat[DMA_STALL] = true;
                         int1_check();
-                        arbitrate();
-                        break;
+                        channels[EE_SIF1].has_dma_stalled = true;
                     }
+                    arbitrate();
+                    break;
                 }
                 channels[EE_SIF1].has_dma_stalled = false;
             }
@@ -1722,9 +1727,10 @@ void DMAC::check_for_activation(int index)
                 printf("DMA Stall Drain channel %d Addr %x STADR %x\n", index, channels[index].address, STADR);
                 interrupt_stat.channel_stat[DMA_STALL] = true;
                 int1_check();
-                queued_channels.push_back(&channels[index]);
-                return;
+                channels[index].has_dma_stalled = true;
             }
+            queued_channels.push_back(&channels[index]);
+            return;
         }
 
         if (!active_channel)

--- a/src/core/ee/dmac.cpp
+++ b/src/core/ee/dmac.cpp
@@ -534,8 +534,7 @@ int DMAC::process_IPU_FROM()
             uint128_t data = ipu->read_FIFO();
             store128(channels[IPU_FROM].address, data);
 
-            channels[IPU_FROM].address += 16;
-            channels[IPU_FROM].quadword_count--;
+            advance_dest_dma(IPU_FROM);
             count++;
         }
     }
@@ -914,6 +913,9 @@ void DMAC::advance_dest_dma(int index)
             update_stadr(channels[index].address);
         //SPR_FROM source stall drain
         if (index == 8 && control.stall_source_channel == 2)
+            update_stadr(channels[index].address);
+        //IPU_FROM source stall drain
+        if (index == 3 && control.stall_source_channel == 3)
             update_stadr(channels[index].address);
     }
 }

--- a/src/core/ee/dmac.cpp
+++ b/src/core/ee/dmac.cpp
@@ -423,7 +423,7 @@ int DMAC::process_GIF()
                     }
 
                     arbitrate();
-                    break;
+                    return count;
                 }
                 channels[GIF].has_dma_stalled = false;
             }

--- a/src/core/ee/dmac.cpp
+++ b/src/core/ee/dmac.cpp
@@ -285,7 +285,7 @@ int DMAC::process_VIF1()
                     channels[VIF1].has_dma_stalled = true;
                 }
 
-                arbitrate();
+                clear_DMA_request(VIF1);
                 return count;
             }
             channels[VIF1].has_dma_stalled = false;
@@ -414,7 +414,7 @@ int DMAC::process_GIF()
                     channels[GIF].has_dma_stalled = true;
                 }
 
-                arbitrate();
+                clear_DMA_request(GIF);
                 return count;
             }
             channels[GIF].has_dma_stalled = false;
@@ -705,7 +705,7 @@ int DMAC::process_SIF1()
                     int1_check();
                     channels[EE_SIF1].has_dma_stalled = true;
                 }
-                arbitrate();
+                clear_DMA_request(EE_SIF1);
                 return count;
             }
             channels[EE_SIF1].has_dma_stalled = false;
@@ -1650,7 +1650,7 @@ void DMAC::write32(uint32_t address, uint32_t value)
             break;
         case 0x1000E060:
             printf("[DMAC] Write to STADR: $%08X\n", value);
-            STADR = value;
+            update_stadr(value);
             break;
         default:
             printf("[DMAC] Unrecognized write32 of $%08X to $%08X\n", value, address);
@@ -1699,9 +1699,8 @@ void DMAC::update_stadr(uint32_t addr)
             Errors::die("DMAC::update_stadr: control.stall_dest_channel >= 4");
     }
 
-    uint32_t madr = channels[c].address + (8 * 16);
-    if (madr > old_stadr && madr <= STADR)
-        check_for_activation(c);
+    if(channels[c].has_dma_stalled)
+        set_DMA_request(c);
 }
 
 void DMAC::check_for_activation(int index)

--- a/src/core/ee/dmac.cpp
+++ b/src/core/ee/dmac.cpp
@@ -693,11 +693,18 @@ int DMAC::process_SIF1()
         {
             if (control.stall_dest_channel == 3 && channels[EE_SIF1].can_stall_drain)
             {
-                if (channels[EE_SIF1].address + (8 * 16) > STADR)
+                if (channels[EE_SIF1].address == STADR)
                 {
-                    active_channel = nullptr;
-                    break;
+                    if (channels[EE_SIF1].has_dma_stalled == false)
+                    {
+                        printf("[DMAC] SIF1 DMA Stall at %x STADR = %x\n", channels[EE_SIF1].address, STADR);
+                        interrupt_stat.channel_stat[DMA_STALL] = true;
+                        int1_check();
+                        arbitrate();
+                        break;
+                    }
                 }
+                channels[EE_SIF1].has_dma_stalled = false;
             }
             sif->write_SIF1(fetch128(channels[EE_SIF1].address));
             advance_source_dma(EE_SIF1);

--- a/src/core/ee/dmac.hpp
+++ b/src/core/ee/dmac.hpp
@@ -18,6 +18,7 @@ enum DMAC_CHANNELS
     EE_SIF2,
     SPR_FROM,
     SPR_TO,
+    DMA_STALL = 13,
     MFIFO_EMPTY = 14
 };
 
@@ -42,6 +43,7 @@ struct DMA_Channel
 
     bool started;
     bool can_stall_drain;
+    bool has_dma_stalled;
     bool dma_req;
     bool is_spr;
 

--- a/src/core/ee/ipu/ipu.cpp
+++ b/src/core/ee/ipu/ipu.cpp
@@ -146,7 +146,7 @@ void ImageProcessingUnit::run()
                     break;
                 case 0x05:
                     if (!in_FIFO.advance_stream(command_option & 0x3F))
-                        return;
+                        break;
                     while (bytes_left && in_FIFO.f.size())
                     {
                         uint32_t value;
@@ -1179,7 +1179,7 @@ uint128_t ImageProcessingUnit::read_FIFO()
 void ImageProcessingUnit::write_FIFO(uint128_t quad)
 {
     printf("[IPU] Write FIFO: $%08X_%08X_%08X_%08X\n", quad._u32[3], quad._u32[2], quad._u32[1], quad._u32[0]);
-    dmac->clear_DMA_request(IPU_TO);
+    
 
     //Certain games (Theme Park, Neo Contra, etc) read command output without sending a command.
     //They expect to read the first word of a newly started IPU_TO transfer.
@@ -1188,6 +1188,11 @@ void ImageProcessingUnit::write_FIFO(uint128_t quad)
         command_output = quad._u32[0];
         command_output = (command_output >> 24) | (((command_output >> 16) & 0xFF) << 8) |
                          (((command_output >> 8) & 0xFF) << 16) | (command_output << 24);
+    }
+    if (in_FIFO.f.size() == 7)
+    {
+        dmac->clear_DMA_request(IPU_TO);
+        printf("IPU TO FIFO FULL\n");
     }
     if (in_FIFO.f.size() >= 8)
     {

--- a/src/core/serialize.cpp
+++ b/src/core/serialize.cpp
@@ -4,7 +4,7 @@
 
 #define VER_MAJOR 0
 #define VER_MINOR 0
-#define VER_REV 32
+#define VER_REV 33
 
 using namespace std;
 


### PR DESCRIPTION
Disable PATH3 when stalled by MFIFO Empty
Correct DMA Stall behaviour
Fixes:
Parappa the Rapper 2
Theme Park Rollercoaster (to an extent)
Star Trek Voyager Elite Force
Earth Defence Force 2

Probably Fixes:

Pirates - The Legend of Black Kat
F1 2001

