### PR TITLE
qt: workaround for window title update

### DIFF
--- a/src/qt/emuwindow.cpp
+++ b/src/qt/emuwindow.cpp
@@ -536,6 +536,9 @@ void EmuWindow::keyReleaseEvent(QKeyEvent *event)
 
 void EmuWindow::update_FPS(double FPS)
 {
+    if (disable_fps_updates)
+        return;
+
     if(FPS > 0.01) {
         frametime_avg = 0.8 * frametime_avg + 0.2 / FPS;
         frametime_list[frametime_list_index] = 1. / FPS;
@@ -547,8 +550,6 @@ void EmuWindow::update_FPS(double FPS)
     {
         if(frametime_list[i] > worst_frame_time) worst_frame_time = frametime_list[i];
     }
-
-
 
     framerate_avg = 0.8 * framerate_avg + 0.2 * FPS;
 
@@ -674,12 +675,14 @@ void EmuWindow::save_state()
 
 void EmuWindow::show_default_view()
 {
+    disable_fps_updates = true;
     stack_widget->setCurrentIndex(0);
     setWindowTitle(QApplication::applicationName());
 }
 
 void EmuWindow::show_render_view()
 {
+    disable_fps_updates = false;
     stack_widget->setCurrentIndex(1);
 }
 

--- a/src/qt/emuwindow.hpp
+++ b/src/qt/emuwindow.hpp
@@ -20,10 +20,13 @@ class EmuWindow : public QMainWindow
         EmuThread emu_thread;
         QString ee_mode;
         QString vu1_mode;
+
         std::chrono::system_clock::time_point old_frametime;
         double framerate_avg, frametime_avg;
         double frametime_list[60];
         int frametime_list_index = 0;
+
+        bool disable_fps_updates{ false };
 
         QFileInfo current_ROM;
         QMenu* file_menu;


### PR DESCRIPTION
emuthread might update the title after it gets reset to default state
workaround this for now