### PR TITLE
Fix SIGNAL not pending IRQ when IMR masked

### DIFF
--- a/src/core/ee/ipu/ipu.cpp
+++ b/src/core/ee/ipu/ipu.cpp
@@ -145,8 +145,11 @@ void ImageProcessingUnit::run()
                         process_FDEC();
                     break;
                 case 0x05:
-                    if (!in_FIFO.advance_stream(command_option & 0x3F))
-                        break;
+                    if (!bytes_left)
+                    {
+                        if (!in_FIFO.advance_stream(command_option & 0x3F))
+                            break;
+                    }
                     while (bytes_left && in_FIFO.f.size())
                     {
                         uint32_t value;

--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -109,15 +109,12 @@ void Emulator::run()
         iop.run(iop_cycles);
         iop.interrupt_check(IOP_I_CTRL && (IOP_I_MASK & IOP_I_STAT));
 
-        for (int i = 0; i < bus_cycles; i += 8)
-        {
-            dmac.run(8);
-            timers.run(8);
-            ipu.run();
-            vif0.update(8);
-            vif1.update(8);
-            gif.run(8);
-        }
+        dmac.run(bus_cycles);
+        timers.run(bus_cycles);
+        ipu.run();
+        vif0.update(bus_cycles);
+        vif1.update(bus_cycles);
+        gif.run(bus_cycles);
         
         //VU's run at EE speed, however VU0 maintains its own speed
         vu0.run(ee_cycles);

--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -104,21 +104,25 @@ void Emulator::run()
         scheduler.update_cycle_counts();
 
         cpu.run(ee_cycles);
-        dmac.run(bus_cycles);
-        timers.run(bus_cycles);
-        ipu.run();
-        vif0.update(bus_cycles);
-        vif1.update(bus_cycles);
-        gif.run(bus_cycles);
+        iop_timers.run(iop_cycles);
+        iop_dma.run(iop_cycles);
+        iop.run(iop_cycles);
+        iop.interrupt_check(IOP_I_CTRL && (IOP_I_MASK & IOP_I_STAT));
+
+        for (int i = 0; i < bus_cycles; i += 8)
+        {
+            dmac.run(8);
+            timers.run(8);
+            ipu.run();
+            vif0.update(8);
+            vif1.update(8);
+            gif.run(8);
+        }
         
         //VU's run at EE speed, however VU0 maintains its own speed
         vu0.run(ee_cycles);
         vu1_run_func(vu1, ee_cycles);
 
-        iop_timers.run(iop_cycles);
-        iop_dma.run(iop_cycles);
-        iop.run(iop_cycles);
-        iop.interrupt_check(IOP_I_CTRL && (IOP_I_MASK & IOP_I_STAT));
 
         scheduler.process_events(this);
     }

--- a/src/core/gs.cpp
+++ b/src/core/gs.cpp
@@ -208,8 +208,13 @@ void GraphicsSynthesizer::write64(uint32_t addr, uint64_t value)
     //We need a check for SIGNAL here so that we can fire the interrupt
     if (addr == 0x60)
     {
-        if (!reg.IMR.signal && !reg.CSR.SIGNAL_generated && !reg.CSR.SIGNAL_irq_pending)
-            intc->assert_IRQ((int)Interrupt::GS);
+        if (reg.CSR.SIGNAL_generated)
+        {
+            if(!reg.IMR.signal)
+                intc->assert_IRQ((int)Interrupt::GS);
+            else
+                reg.CSR.SIGNAL_irq_pending = true;
+        }
     }
 
     //also check for interrupt pre-processing


### PR DESCRIPTION
Fix tag setting on DMA resume if the mode is changed, also handle tag IRQ's
Loop around DMA's 8 cycles per time when more than 8 cycles have been provided
Fix IPU SETIQ from accidentally fastforwarding the FIFO more than once if not enough data is available