### PR TITLE
Fix GS Write 64 address mask, Fixes Online Network Configurator in games

### DIFF
--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -780,7 +780,7 @@ void GraphicsSynthesizerThread::write64(uint32_t addr, uint64_t value)
 {
     if (reg.write64(addr, value))
         return;
-    addr &= 0xFFFF;
+    addr &= 0x7F;
     switch (addr)
     {
         case 0x0000:


### PR DESCRIPTION
Working for the first time in PS2 emulation (except PS3 with HW GS)