### PR TITLE
IPU fixes

### DIFF
--- a/src/core/ee/ipu/ipu.cpp
+++ b/src/core/ee/ipu/ipu.cpp
@@ -926,9 +926,6 @@ bool ImageProcessingUnit::process_CSC()
                 uint8_t* cb_block = csc.block + 0x100;
                 uint8_t* cr_block = csc.block + 0x140;
 
-                uint32_t alpha_thresh0 = (TH0 & 0xFF) | ((TH0 & 0xFF) << 8) | ((TH0 & 0xFF) << 16);
-                uint32_t alpha_thresh1 = (TH1 & 0xFF) | ((TH1 & 0xFF) << 8) | ((TH1 & 0xFF) << 16);
-
                 for (int i = 0; i < 16; i++)
                 {
                     for (int j = 0; j < 16; j++)
@@ -960,9 +957,9 @@ bool ImageProcessingUnit::process_CSC()
                         color |= ((uint8_t)b) << 16;
 
                         uint32_t alpha;
-                        if (r < (TH0 & 0xFF) && g < ((TH0 >> 8) & 0xFF) && b < ((TH0 >> 16) & 0xFF))
+                        if (r < TH0 && g < TH0 && b < TH0)
                             alpha = 0;
-                        else if (r < (TH1 & 0xFF) && g < ((TH1 >> 8) & 0xFF) && b < ((TH1 >> 16) & 0xFF))
+                        else if (r < TH1 && g < TH1 && b < TH1)
                             alpha = 1 << 30;
                         else
                             alpha = 1 << 31;

--- a/src/core/ee/ipu/ipu.hpp
+++ b/src/core/ee/ipu/ipu.hpp
@@ -62,6 +62,7 @@ enum class IDEC_STATE
     INIT_CSC,
     EXEC_CSC,
     CHECK_START_CODE,
+    VALID_START_CODE,
     MACRO_INC,
     DONE
 };
@@ -69,7 +70,6 @@ enum class IDEC_STATE
 struct IDEC_Command
 {
     IDEC_STATE state;
-    int delay;
     uint32_t macro_type;
 
     bool decodes_dct;

--- a/src/core/ee/ipu/ipu_fifo.cpp
+++ b/src/core/ee/ipu/ipu_fifo.cpp
@@ -74,3 +74,10 @@ void IPU_FIFO::reset()
     cached_bits = 0;
     bit_cache_dirty = true;
 }
+
+void IPU_FIFO::byte_align()
+{
+    int bits = bit_pointer & 0x7;
+    if (bits)
+        advance_stream(8 - bits);
+}

--- a/src/core/ee/ipu/ipu_fifo.hpp
+++ b/src/core/ee/ipu/ipu_fifo.hpp
@@ -15,6 +15,7 @@ struct IPU_FIFO
     bool advance_stream(uint8_t amount);
 
     void reset();
+    void byte_align();
 };
 
 #endif // IPU_FIFO_HPP

--- a/src/core/serialize.cpp
+++ b/src/core/serialize.cpp
@@ -4,7 +4,7 @@
 
 #define VER_MAJOR 0
 #define VER_MINOR 0
-#define VER_REV 33
+#define VER_REV 34
 
 using namespace std;
 


### PR DESCRIPTION
This PR fixes a bug in IDEC which caused start codes to be improperly parsed, causing hangs in many games. It also fixes a bug related to alpha thresholds.