### PR TITLE
IOP: Organize interrupts in a separate class

### DIFF
--- a/DobieStation/Core.vcxproj
+++ b/DobieStation/Core.vcxproj
@@ -126,6 +126,7 @@
     <ClCompile Include="$(CoreDir)iop\iop.cpp" />
     <ClCompile Include="$(CoreDir)iop\iop_cop0.cpp" />
     <ClCompile Include="$(CoreDir)iop\iop_dma.cpp" />
+    <ClCompile Include="$(CoreDir)iop\iop_intc.cpp" />
     <ClCompile Include="$(CoreDir)iop\iop_interpreter.cpp" />
     <ClCompile Include="$(CoreDir)iop\iop_timers.cpp" />
     <ClCompile Include="$(CoreDir)ee\ipu\ipu.cpp" />
@@ -195,6 +196,7 @@
     <ClInclude Include="$(CoreDir)iop\iop.hpp" />
     <ClInclude Include="$(CoreDir)iop\iop_cop0.hpp" />
     <ClInclude Include="$(CoreDir)iop\iop_dma.hpp" />
+    <ClInclude Include="$(CoreDir)iop\iop_intc.hpp" />
     <ClInclude Include="$(CoreDir)iop\iop_interpreter.hpp" />
     <ClInclude Include="$(CoreDir)iop\iop_timers.hpp" />
     <ClInclude Include="$(CoreDir)ee\ipu\ipu.hpp" />

--- a/DobieStation/Core.vcxproj.filters
+++ b/DobieStation/Core.vcxproj.filters
@@ -146,6 +146,9 @@
     <ClCompile Include="$(CoreDir)iop\iop_dma.cpp">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="$(CoreDir)iop\iop_intc.cpp">
+      <Filter>Source</Filter>
+    </ClCompile>
     <ClCompile Include="$(CoreDir)iop\iop_interpreter.cpp">
       <Filter>Source</Filter>
     </ClCompile>
@@ -343,6 +346,9 @@
     <ClInclude Include="$(CoreDir)iop\iop_dma.hpp">
       <Filter>Headers</Filter>
     </ClInclude>
+    <ClCompile Include="$(CoreDir)iop\iop_intc.hpp”>
+      <Filter>Source</Filter>
+    </ClCompile>
     <ClInclude Include="$(CoreDir)iop\iop_interpreter.hpp">
       <Filter>Headers</Filter>
     </ClInclude>

--- a/DobieStation/application/application.pro
+++ b/DobieStation/application/application.pro
@@ -101,7 +101,8 @@ SOURCES += ../../src/qt/main.cpp \
     ../../src/core/ee/ee_jit64_fpu_avx.cpp \
     ../../src/core/ee/ee_jit64_gpr.cpp \
     ../../src/core/iop/cdvd/iso_reader.cpp \
-    ../../src/core/iop/cdvd/bincuereader.cpp
+    ../../src/core/iop/cdvd/bincuereader.cpp \
+    ../../src/core/iop/iop_intc.cpp
 
 HEADERS += \
     ../../src/core/errors.hpp \
@@ -174,5 +175,6 @@ HEADERS += \
     ../../src/core/ee/ee_jit64.hpp \
     ../../src/core/iop/cdvd/cdvd_container.hpp \
     ../../src/core/iop/cdvd/iso_reader.hpp \
-    ../../src/core/iop/cdvd/bincuereader.hpp
+    ../../src/core/iop/cdvd/bincuereader.hpp \
+    ../../src/core/iop/iop_intc.hpp
    

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -74,6 +74,7 @@ set(SOURCES
     iop/iop.cpp
     iop/iop_cop0.cpp
     iop/iop_dma.cpp
+    iop/iop_intc.cpp
     iop/iop_interpreter.cpp
     iop/iop_timers.cpp
     iop/memcard.cpp
@@ -150,6 +151,7 @@ set(HEADERS
     iop/iop.hpp
     iop/iop_cop0.hpp
     iop/iop_dma.hpp
+    iop/iop_intc.hpp
     iop/iop_interpreter.hpp
     iop/iop_timers.hpp
     iop/memcard.hpp

--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -25,6 +25,7 @@ Emulator::Emulator() :
     gs(&intc),
     iop(this),
     iop_dma(this, &cdvd, &sif, &sio2, &spu, &spu2),
+    iop_intc(&iop),
     iop_timers(this, &scheduler),
     intc(&cpu, &scheduler),
     ipu(&intc, &dmac),
@@ -106,7 +107,6 @@ void Emulator::run()
         cpu.run(ee_cycles);
         iop_dma.run(iop_cycles);
         iop.run(iop_cycles);
-        iop.interrupt_check(IOP_I_CTRL && (IOP_I_MASK & IOP_I_STAT));
 
         dmac.run(bus_cycles);
         ipu.run();
@@ -128,7 +128,6 @@ void Emulator::reset()
     save_requested = false;
     load_requested = false;
     gsdump_requested = false;
-    iop_i_ctrl_delay = 0;
     ee_stdout = "";
     frames = 0;
     skip_BIOS_hack = NONE;
@@ -157,6 +156,7 @@ void Emulator::reset()
     gif.reset();
     iop.reset();
     iop_dma.reset(IOP_RAM);
+    iop_intc.reset();
     iop_timers.reset();
     intc.reset();
     ipu.reset();
@@ -176,9 +176,6 @@ void Emulator::reset()
     MCH_DRD = 0;
     MCH_RICM = 0;
     rdram_sdevid = 0;
-    IOP_I_STAT = 0;
-    IOP_I_MASK = 0;
-    IOP_I_CTRL = 0;
     IOP_POST = 0;
     clear_cop2_interlock();
 
@@ -1134,16 +1131,11 @@ uint32_t Emulator::iop_read32(uint32_t address)
             printf("[IOP] Read BD4: $%08X\n", sif.get_control() | 0xF0000002);
             return sif.get_control() | 0xF0000002;
         case 0x1F801070:
-            return IOP_I_STAT;
+            return iop_intc.read_istat();
         case 0x1F801074:
-            return IOP_I_MASK;
+            return iop_intc.read_imask();
         case 0x1F801078:
-        {
-            //I_CTRL is reset when read
-            uint32_t value = IOP_I_CTRL;
-            IOP_I_CTRL = 0;
-            return value;
-        }
+            return iop_intc.read_ictrl();
         case 0x1F8010B0:
             return iop_dma.get_chan_addr(3);
         case 0x1F8010B8:
@@ -1459,21 +1451,13 @@ void Emulator::iop_write32(uint32_t address, uint32_t value)
             printf("[IOP] SPU SSBUS: $%08X\n", value);
             return;
         case 0x1F801070:
-            //printf("[IOP] I_STAT: $%08X\n", value);
-            IOP_I_STAT &= value;
-            iop.interrupt_check(IOP_I_CTRL && (IOP_I_MASK & IOP_I_STAT));
+            iop_intc.write_istat(value);
             return;
         case 0x1F801074:
-            //printf("[IOP] I_MASK: $%08X\n", value);
-            IOP_I_MASK = value;
-            iop.interrupt_check(IOP_I_CTRL && (IOP_I_MASK & IOP_I_STAT));
+            iop_intc.write_imask(value);
             return;
         case 0x1F801078:
-            if (!IOP_I_CTRL && (value & 0x1))
-                iop_i_ctrl_delay = 4;
-            IOP_I_CTRL = value & 0x1;
-            //iop.interrupt_check(IOP_I_CTRL && (IOP_I_MASK & IOP_I_STAT));
-            //printf("[IOP] I_CTRL: $%08X\n", value);
+            iop_intc.write_ictrl(value);
             return;
         //CDVD DMA
         case 0x1F8010B0:
@@ -1648,9 +1632,7 @@ void Emulator::iop_write32(uint32_t address, uint32_t value)
 void Emulator::iop_request_IRQ(int index)
 {
     printf("[IOP] Requesting IRQ %d\n", index);
-    uint32_t new_stat = IOP_I_STAT | (1 << index);
-    IOP_I_STAT = new_stat;
-    iop.interrupt_check(IOP_I_CTRL && (IOP_I_MASK & IOP_I_STAT));
+    iop_intc.assert_irq(index);
 }
 
 void Emulator::iop_ksprintf()

--- a/src/core/emulator.hpp
+++ b/src/core/emulator.hpp
@@ -15,6 +15,7 @@
 #include "iop/gamepad.hpp"
 #include "iop/iop.hpp"
 #include "iop/iop_dma.hpp"
+#include "iop/iop_intc.hpp"
 #include "iop/iop_timers.hpp"
 #include "iop/memcard.hpp"
 #include "iop/sio2.hpp"
@@ -91,10 +92,8 @@ class Emulator
         uint8_t rdram_sdevid;
 
         uint8_t IOP_POST;
-        uint32_t IOP_I_STAT;
-        uint32_t IOP_I_MASK;
-        uint32_t IOP_I_CTRL;
-        int iop_i_ctrl_delay;
+
+        IOP_INTC iop_intc;
 
         SKIP_HACK skip_BIOS_hack;
 

--- a/src/core/emulator.hpp
+++ b/src/core/emulator.hpp
@@ -164,7 +164,6 @@ class Emulator
         void iop_write16(uint32_t address, uint16_t value);
         void iop_write32(uint32_t address, uint32_t value);
 
-        void iop_request_IRQ(int index);
         void iop_ksprintf();
         void iop_puts();
 

--- a/src/core/iop/cdvd/cdvd.hpp
+++ b/src/core/iop/cdvd/cdvd.hpp
@@ -5,7 +5,7 @@
 #include <memory>
 #include "cdvd_container.hpp"
 
-class Emulator;
+class IOP_INTC;
 class IOP_DMA;
 class Scheduler;
 
@@ -59,7 +59,7 @@ class CDVD_Drive
     private:
         uint64_t last_read;
         uint64_t cycle_count;
-        Emulator* e;
+        IOP_INTC* intc;
         IOP_DMA* dma;
         CDVD_DISC_TYPE disc_type;
         std::unique_ptr<CDVD_Container> container;
@@ -120,7 +120,7 @@ class CDVD_Drive
         void S_command_sub(uint8_t func);
         void add_event(uint64_t cycles);
     public:
-        CDVD_Drive(Emulator* e, IOP_DMA* dma, Scheduler* scheduler);
+        CDVD_Drive(IOP_INTC* intc, IOP_DMA* dma, Scheduler* scheduler);
         ~CDVD_Drive();
 
         std::string get_serial();

--- a/src/core/iop/iop_dma.hpp
+++ b/src/core/iop/iop_dma.hpp
@@ -49,8 +49,8 @@ struct DMA_DICR
     bool master_int_enable[2];
 };
 
-class Emulator;
 class CDVD_Drive;
+class IOP_INTC;
 class SubsystemInterface;
 class SIO2;
 class SPU;
@@ -76,7 +76,7 @@ class IOP_DMA
 {
     private:
         uint8_t* RAM;
-        Emulator* e;
+        IOP_INTC* intc;
         CDVD_Drive* cdvd;
         SubsystemInterface* sif;
         SIO2* sio2;
@@ -104,7 +104,7 @@ class IOP_DMA
         void apply_dma_functions();
     public:
         static const char* CHAN(int index);
-        IOP_DMA(Emulator* e, CDVD_Drive* cdvd, SubsystemInterface* sif, SIO2* sio2, SPU* spu, SPU* spu2);
+        IOP_DMA(IOP_INTC* intc, CDVD_Drive* cdvd, SubsystemInterface* sif, SIO2* sio2, SPU* spu, SPU* spu2);
 
         void reset(uint8_t* RAM);
         void run(int cycles);

--- a/src/core/iop/iop_intc.cpp
+++ b/src/core/iop/iop_intc.cpp
@@ -1,0 +1,62 @@
+#include "iop.hpp"
+#include "iop_intc.hpp"
+
+IOP_INTC::IOP_INTC(IOP* iop) : iop(iop)
+{
+
+}
+
+void IOP_INTC::int_check()
+{
+    iop->interrupt_check(I_CTRL && (I_STAT & I_MASK));
+}
+
+void IOP_INTC::reset()
+{
+    I_MASK = 0;
+    I_STAT = 0;
+    I_CTRL = 0;
+}
+
+void IOP_INTC::assert_irq(int id)
+{
+    I_STAT |= 1 << id;
+    int_check();
+}
+
+uint32_t IOP_INTC::read_imask()
+{
+    return I_MASK;
+}
+
+uint32_t IOP_INTC::read_istat()
+{
+    return I_STAT;
+}
+
+uint32_t IOP_INTC::read_ictrl()
+{
+    //I_CTRL disables interrupts when read
+    uint32_t value = I_CTRL;
+    I_CTRL = 0;
+    int_check();
+    return value;
+}
+
+void IOP_INTC::write_imask(uint32_t value)
+{
+    I_MASK = value;
+    int_check();
+}
+
+void IOP_INTC::write_istat(uint32_t value)
+{
+    I_STAT &= value;
+    int_check();
+}
+
+void IOP_INTC::write_ictrl(uint32_t value)
+{
+    I_CTRL = value & 0x1;
+    int_check();
+}

--- a/src/core/iop/iop_intc.hpp
+++ b/src/core/iop/iop_intc.hpp
@@ -1,0 +1,34 @@
+#ifndef IOP_INTC_HPP
+#define IOP_INTC_HPP
+#include <cstdint>
+#include <fstream>
+
+class IOP;
+
+class IOP_INTC
+{
+    private:
+        IOP* iop;
+
+        uint32_t I_STAT, I_MASK, I_CTRL;
+
+        void int_check();
+    public:
+        IOP_INTC(IOP* iop);
+
+        void reset();
+        void assert_irq(int id);
+
+        uint32_t read_imask();
+        uint32_t read_istat();
+        uint32_t read_ictrl();
+
+        void write_imask(uint32_t value);
+        void write_istat(uint32_t value);
+        void write_ictrl(uint32_t value);
+
+        void load_state(std::ifstream& state);
+        void save_state(std::ofstream& state);
+};
+
+#endif // IOP_INTC_HPP

--- a/src/core/iop/iop_timers.cpp
+++ b/src/core/iop/iop_timers.cpp
@@ -1,11 +1,12 @@
 #include <algorithm>
 #include <cstdio>
 #include "iop_timers.hpp"
+#include "iop_intc.hpp"
 #include "../emulator.hpp"
 #include "../errors.hpp"
 #include "../scheduler.hpp"
 
-IOPTiming::IOPTiming(Emulator* e, Scheduler* scheduler) : e(e), scheduler(scheduler)
+IOPTiming::IOPTiming(IOP_INTC* intc, Scheduler* scheduler) : intc(intc), scheduler(scheduler)
 {
 
 }
@@ -57,7 +58,7 @@ void IOPTiming::IRQ_test(int index, bool overflow)
     if (timers[index].control.int_enable)
     {
         const static int IRQs[] = {4, 5, 6, 14, 15, 16};
-        e->iop_request_IRQ(IRQs[index]);
+        intc->assert_irq(IRQs[index]);
 
         if (overflow)
             timers[index].control.overflow_interrupt = true;

--- a/src/core/iop/iop_timers.hpp
+++ b/src/core/iop/iop_timers.hpp
@@ -27,13 +27,13 @@ struct IOP_Timer
     uint64_t target;
 };
 
-class Emulator;
+class IOP_INTC;
 class Scheduler;
 
 class IOPTiming
 {
     private:
-        Emulator* e;
+        IOP_INTC* intc;
         Scheduler* scheduler;
 
         IOP_Timer timers[6];
@@ -44,7 +44,7 @@ class IOPTiming
         void timer_interrupt(int index);
         void IRQ_test(int index, bool overflow);
     public:
-        IOPTiming(Emulator* e, Scheduler* scheduler);
+        IOPTiming(IOP_INTC* intc, Scheduler* scheduler);
 
         void reset();
         uint32_t read_counter(int index);

--- a/src/core/iop/sio2.cpp
+++ b/src/core/iop/sio2.cpp
@@ -1,14 +1,14 @@
 #include <cstdio>
 #include "gamepad.hpp"
+#include "iop_intc.hpp"
 #include "memcard.hpp"
 #include "sio2.hpp"
 
-#include "../emulator.hpp"
 #include "../errors.hpp"
 
 using namespace std;
 
-SIO2::SIO2(Emulator* e, Gamepad* pad, Memcard* memcard) : e(e), pad(pad), memcard(memcard)
+SIO2::SIO2(IOP_INTC* intc, Gamepad* pad, Memcard* memcard) : intc(intc), pad(pad), memcard(memcard)
 {
 
 }
@@ -140,7 +140,7 @@ void SIO2::set_control(uint32_t value)
 
     if (value & 0x1)
     {
-        e->iop_request_IRQ(17);
+        intc->assert_irq(17);
         control &= ~0x1;
     }
     else

--- a/src/core/iop/sio2.hpp
+++ b/src/core/iop/sio2.hpp
@@ -12,14 +12,14 @@ enum class SIO_DEVICE
     DUMMY
 };
 
-class Emulator;
+class IOP_INTC;
 class Gamepad;
 class Memcard;
 
 class SIO2
 {
     private:
-        Emulator* e;
+        IOP_INTC* intc;
         Gamepad* pad;
         Memcard* memcard;
 
@@ -42,7 +42,7 @@ class SIO2
 
         void write_device(uint8_t value);
     public:
-        SIO2(Emulator* e, Gamepad* pad, Memcard* memcard);
+        SIO2(IOP_INTC* intc, Gamepad* pad, Memcard* memcard);
 
         void reset();
 

--- a/src/core/iop/spu.cpp
+++ b/src/core/iop/spu.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cstdio>
 #include "spu.hpp"
 #include "iop_dma.hpp"

--- a/src/core/iop/spu.cpp
+++ b/src/core/iop/spu.cpp
@@ -1,7 +1,7 @@
 #include <cstdio>
 #include "spu.hpp"
-#include "../emulator.hpp"
 #include "iop_dma.hpp"
+#include "iop_intc.hpp"
 
 /**
  * Notes on "AutoDMA", as it seems to not be documented anywhere else
@@ -13,7 +13,7 @@
 uint16_t SPU::spdif_irq = 0;
 uint16_t SPU::core_att[2];
 uint32_t SPU::IRQA[2];
-SPU::SPU(int id, Emulator* e, IOP_DMA* dma) : id(id), e(e), dma(dma)
+SPU::SPU(int id, IOP_INTC* intc, IOP_DMA* dma) : id(id), intc(intc), dma(dma)
 { 
 
 }
@@ -61,7 +61,7 @@ void SPU::spu_irq(int index)
 
     printf("[SPU%d] IRQA interrupt!\n", index);
     spdif_irq |= 4 << index;
-    e->iop_request_IRQ(9);
+    intc->assert_irq(9);
 }
 
 void SPU::gen_sample()

--- a/src/core/iop/spu.hpp
+++ b/src/core/iop/spu.hpp
@@ -43,14 +43,14 @@ struct SPU_STAT
     bool DMA_busy;
 };
 
-class Emulator;
+class IOP_INTC;
 class IOP_DMA;
 
 class SPU
 {
     private:
         int id;
-        Emulator* e;
+        IOP_INTC* intc;
         IOP_DMA* dma;
 
         uint16_t* RAM;
@@ -91,7 +91,7 @@ class SPU
         void clear_dma_req();
         void set_dma_req();
     public:
-        SPU(int id, Emulator* e, IOP_DMA* dma);
+        SPU(int id, IOP_INTC* intc, IOP_DMA* dma);
 
         bool running_ADMA();
         bool can_write_ADMA();

--- a/src/core/serialize.cpp
+++ b/src/core/serialize.cpp
@@ -4,7 +4,7 @@
 
 #define VER_MAJOR 0
 #define VER_MINOR 0
-#define VER_REV 37
+#define VER_REV 38
 
 using namespace std;
 
@@ -87,10 +87,7 @@ void Emulator::load_state(const char *file_name)
 
     //Interrupt registers
     intc.load_state(state);
-    state.read((char*)&IOP_I_CTRL, sizeof(uint32_t));
-    state.read((char*)&IOP_I_MASK, sizeof(uint32_t));
-    state.read((char*)&IOP_I_STAT, sizeof(uint32_t));
-    state.read((char*)&iop_i_ctrl_delay, sizeof(iop_i_ctrl_delay));
+    iop_intc.load_state(state);
 
     //Timers
     timers.load_state(state);
@@ -165,10 +162,7 @@ void Emulator::save_state(const char *file_name)
 
     //Interrupt registers
     intc.save_state(state);
-    state.write((char*)&IOP_I_CTRL, sizeof(uint32_t));
-    state.write((char*)&IOP_I_MASK, sizeof(uint32_t));
-    state.write((char*)&IOP_I_STAT, sizeof(uint32_t));
-    state.write((char*)&iop_i_ctrl_delay, sizeof(iop_i_ctrl_delay));
+    iop_intc.save_state(state);
 
     //Timers
     timers.save_state(state);
@@ -477,6 +471,20 @@ void INTC::save_state(ofstream &state)
     state.write((char*)&INTC_STAT, sizeof(INTC_STAT));
     state.write((char*)&stat_speedhack_active, sizeof(stat_speedhack_active));
     state.write((char*)&read_stat_count, sizeof(read_stat_count));
+}
+
+void IOP_INTC::load_state(ifstream &state)
+{
+    state.read((char*)&I_CTRL, sizeof(I_CTRL));
+    state.read((char*)&I_STAT, sizeof(I_STAT));
+    state.read((char*)&I_MASK, sizeof(I_MASK));
+}
+
+void IOP_INTC::save_state(ofstream &state)
+{
+    state.write((char*)&I_CTRL, sizeof(I_CTRL));
+    state.write((char*)&I_STAT, sizeof(I_STAT));
+    state.write((char*)&I_MASK, sizeof(I_MASK));
 }
 
 void EmotionTiming::load_state(ifstream &state)


### PR DESCRIPTION
This PR allows IOP hardware to raise interrupts without needing knowledge of the Emulator object. While this shouldn't affect accuracy, it does make the design slightly cleaner.