### PR TITLE
Update GS JIT state correctly when Z format used for FRAME and when i…

### DIFF
--- a/src/core/gscontext.cpp
+++ b/src/core/gscontext.cpp
@@ -173,6 +173,18 @@ void GSContext::set_frame(uint64_t value)
     printf("FRAME: $%08X_%08X\n", value >> 32, value & 0xFFFFFFFF);
     printf("Width: %d\n", frame.width);
     printf("Format: %d\n", frame.format);
+
+    // confirmed by hw test
+    // in the event that a z format is specified for FRAME
+    // the depth format will swap to a color format
+    if ((frame.format & 0x30) == 0x30)
+    {
+        zbuf.format &= ~0x30;
+    }
+    else
+    {
+        zbuf.format |= 0x30;
+    }
 }
 
 void GSContext::set_zbuf(uint64_t value)
@@ -183,4 +195,12 @@ void GSContext::set_zbuf(uint64_t value)
     printf("ZBUF: $%08X_%08X\n", value >> 32, value & 0xFFFFFFFF);
     printf("Base pointer: $%08X\n", zbuf.base_pointer);
     printf("Format: $%02X\n", zbuf.format);
+
+    // confirmed by hw test
+    // in the event that a z format is specified for FRAME
+    // the depth format will swap to a color format
+    if ((frame.format & 0x30) == 0x30)
+    {
+        zbuf.format &= ~0x30;
+    }
 }

--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -1474,20 +1474,6 @@ void GraphicsSynthesizerThread::render_primitive()
     if (current_ctx->scissor.empty())
         return;
 
-    // confirmed by hw test
-    // in the event that a z format is specified for FRAME
-    // the depth format will swap to a color format
-    if ((current_ctx->frame.format & 0x30) == 0x30)
-    {
-        current_ctx->zbuf.format &= ~0x30;
-        update_draw_pixel_state();
-    }
-    else
-    {
-        current_ctx->zbuf.format |= 0x30;
-        update_draw_pixel_state();
-    }
-
 #ifdef GS_JIT
     jit_draw_pixel_func = get_jitted_draw_pixel(draw_pixel_state);
     //No need to recompile tex_lookup if texture mapping is disabled. TEX0 can contain bad data

--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -1478,7 +1478,15 @@ void GraphicsSynthesizerThread::render_primitive()
     // in the event that a z format is specified for FRAME
     // the depth format will swap to a color format
     if ((current_ctx->frame.format & 0x30) == 0x30)
+    {
         current_ctx->zbuf.format &= ~0x30;
+        update_draw_pixel_state();
+    }
+    else
+    {
+        current_ctx->zbuf.format |= 0x30;
+        update_draw_pixel_state();
+    }
 
 #ifdef GS_JIT
     jit_draw_pixel_func = get_jitted_draw_pixel(draw_pixel_state);
@@ -4059,12 +4067,12 @@ void GraphicsSynthesizerThread::update_draw_pixel_state()
     draw_pixel_state |= (uint64_t)DTHE << 34UL;
     draw_pixel_state |= (uint64_t)COLCLAMP << 35UL;
     draw_pixel_state |= (uint64_t)current_ctx->zbuf.format << 36UL;
-    draw_pixel_state |= (uint64_t)SCANMSK << 40UL;
-    draw_pixel_state |= (uint64_t)current_ctx->zbuf.no_update << 42UL;
-    draw_pixel_state |= (uint64_t)current_ctx->alpha.fixed_alpha << 43UL;
-    draw_pixel_state |= (uint64_t)(current_PRMODE == &PRIM) << 51UL;
-    draw_pixel_state |= (uint64_t)(current_ctx == &context1) << 52UL;
-    draw_pixel_state |= (uint64_t)(current_ctx->frame.mask != 0) << 53UL;
+    draw_pixel_state |= (uint64_t)SCANMSK << 42UL;
+    draw_pixel_state |= (uint64_t)current_ctx->zbuf.no_update << 44UL;
+    draw_pixel_state |= (uint64_t)current_ctx->alpha.fixed_alpha << 45UL;
+    draw_pixel_state |= (uint64_t)(current_PRMODE == &PRIM) << 53UL;
+    draw_pixel_state |= (uint64_t)(current_ctx == &context1) << 54UL;
+    draw_pixel_state |= (uint64_t)(current_ctx->frame.mask != 0) << 55UL;
 }
 
 void GraphicsSynthesizerThread::update_tex_lookup_state()


### PR DESCRIPTION
…t's switched back

Leave room in the GS JIT Draw state for the larger Z Buffer formatting numbers

Fixes the slicing in the Network Setup menus and slicing in Itadaki Street 3