### PR TITLE
Add Sony PlayStation 3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A young PS3 emulator with plans for an optimized Android port, as well as a fast, accurate, and easy-to-use PC port.
 
-A large portion of the PS3's library can boot or get to menus. Some titles can even go in-game, including high-profile ones such as Final Fantasy X and Shadow of the Colossus. Not intended for general use.
+A large portion of the PS3's library can boot or get to menus. Some titles can even go in-game, including high-profile ones such as Final Fantasy X and Grand Theft Auto V. Not intended for general use.
 
 ## Compiling
 DobieStation uses Qt 5 and supports qmake and CMake.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ For example on Visual Studio 2017: `C:\path\to\qt\5.12.1\msvc2017_64`
 Once the variable is set open `DobieStation\DobieStation.sln` in Visual Studio.
 
 ## Using the Emulator
-DobieStation requires a copy of the PS3 BIOS, which must be dumped from your PS3.
+DobieStation requires a copy of the PS3 firmware, which must be dumped from your PS3.
 
 The various command line options are as follows:
 ```

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 [![GitHub Actions Status](https://github.com/PSI-Rockin/DobieStation/workflows/CI/badge.svg?branch=master)](https://github.com/PSI-Rockin/DobieStation/actions)
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/PSI-Rockin/DobieStation?svg=true)](https://ci.appveyor.com/project/PSI-Rockin/dobiestation)
 
-A young PS2 emulator with plans for an optimized Android port, as well as a fast, accurate, and easy-to-use PC port.
+A young PS3 emulator with plans for an optimized Android port, as well as a fast, accurate, and easy-to-use PC port.
 
-A large portion of the PS2's library can boot or get to menus. Some titles can even go in-game, including high-profile ones such as Final Fantasy X and Shadow of the Colossus. Not intended for general use.
+A large portion of the PS3's library can boot or get to menus. Some titles can even go in-game, including high-profile ones such as Final Fantasy X and Shadow of the Colossus. Not intended for general use.
 
 ## Compiling
 DobieStation uses Qt 5 and supports qmake and CMake.
@@ -58,7 +58,7 @@ For example on Visual Studio 2017: `C:\path\to\qt\5.12.1\msvc2017_64`
 Once the variable is set open `DobieStation\DobieStation.sln` in Visual Studio.
 
 ## Using the Emulator
-DobieStation requires a copy of the PS2 BIOS, which must be dumped from your PS2.
+DobieStation requires a copy of the PS3 BIOS, which must be dumped from your PS3.
 
 The various command line options are as follows:
 ```

--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -1703,7 +1703,7 @@ void Emulator::iop_puts()
     //printf("\n");
 }
 
-GraphicsSynthesizer& Emulator::get_gs()
+GraphicsSynthesizer& Emulator::get_gs() const
 {
     return gs;
 }

--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -1703,7 +1703,7 @@ void Emulator::iop_puts()
     //printf("\n");
 }
 
-GraphicsSynthesizer& Emulator::get_gs() const
+GraphicsSynthesizer& Emulator::get_gs()
 {
     return gs;
 }

--- a/src/core/emulator.hpp
+++ b/src/core/emulator.hpp
@@ -168,7 +168,7 @@ class Emulator
         void iop_puts();
 
         void test_iop();
-        GraphicsSynthesizer& get_gs();
+        GraphicsSynthesizer& get_gs() const;
 };
 
 #endif // EMULATOR_HPP

--- a/src/core/emulator.hpp
+++ b/src/core/emulator.hpp
@@ -168,7 +168,7 @@ class Emulator
         void iop_puts();
 
         void test_iop();
-        GraphicsSynthesizer& get_gs() const;
+        GraphicsSynthesizer& get_gs();
 };
 
 #endif // EMULATOR_HPP

--- a/src/core/emulator.hpp
+++ b/src/core/emulator.hpp
@@ -168,7 +168,7 @@ class Emulator
         void iop_puts();
 
         void test_iop();
-        GraphicsSynthesizer& get_gs();//used for gs dumps
+        GraphicsSynthesizer& get_gs();
 };
 
 #endif // EMULATOR_HPP


### PR DESCRIPTION
This PR implements support for Sony's PlayStation 3 console. I have not thoroughly tested this, but games such as The Last of Us and Skate 3 are able to successfully boot to a black screen so far. Please test for any regressions, as this is a rather large PR.