### PR TITLE
IOP Timing: Do not disable interrupts if repeat is on and toggle is off

### DIFF
--- a/src/core/iop/iop_timers.cpp
+++ b/src/core/iop/iop_timers.cpp
@@ -65,16 +65,11 @@ void IOPTiming::IRQ_test(int index, bool overflow)
         else
             timers[index].control.compare_interrupt = true;
     }
-    else
-    {
-        if (!timers[index].control.repeat_int)
-            return;
-    }
 
-    if (timers[index].control.toggle_int)
-        timers[index].control.int_enable ^= true;
-    else
+    if (!timers[index].control.repeat_int)
         timers[index].control.int_enable = false;
+    else if (timers[index].control.toggle_int)
+        timers[index].control.int_enable ^= true;
 }
 
 uint32_t IOPTiming::read_counter(int index)


### PR DESCRIPTION
Tekken Tag Tournament uses a timer on repeat mode to wake up a thread every so often. Old behavior caused the thread to never wake up after the initial interrupt, causing the game to hang at the Namco splash screen.