### PR TITLE
Fix condition where other GIF paths can start transferring when anoth…

### DIFF
--- a/src/core/ee/vif.cpp
+++ b/src/core/ee/vif.cpp
@@ -109,6 +109,11 @@ void VectorInterface::update(int cycles)
     //This allows us to process one quadword per bus cycle
     int run_cycles = cycles << 2;
    
+    if (vif_stalled & STALL_WAIT)
+    {
+        vif_stalled &= ~STALL_WAIT;
+    }
+
     if (vif_stalled & STALL_MSKPATH3)
     {
         gif->resume_path3();
@@ -234,6 +239,7 @@ bool VectorInterface::process_data_word(uint32_t value)
                 if (!gif->path_active(2, command == 0x50))
                 {
                     direct_wait = true;
+                    vif_stalled |= STALL_WAIT;
                     return false;
                 }
                 direct_wait = false;

--- a/src/core/ee/vif.cpp
+++ b/src/core/ee/vif.cpp
@@ -109,9 +109,11 @@ void VectorInterface::update(int cycles)
     //This allows us to process one quadword per bus cycle
     int run_cycles = cycles << 2;
    
-    if (vif_stalled & STALL_WAIT)
+    //This is just a timing break for when DIRECT/HL runs and the GS path is busy
+    //Saves looping ~64 times when nothing is going to change
+    if (vif_stalled & STALL_DIRECT)
     {
-        vif_stalled &= ~STALL_WAIT;
+        vif_stalled &= ~STALL_DIRECT;
     }
 
     if (vif_stalled & STALL_MSKPATH3)
@@ -239,7 +241,7 @@ bool VectorInterface::process_data_word(uint32_t value)
                 if (!gif->path_active(2, command == 0x50))
                 {
                     direct_wait = true;
-                    vif_stalled |= STALL_WAIT;
+                    vif_stalled |= STALL_DIRECT;
                     return false;
                 }
                 direct_wait = false;

--- a/src/core/ee/vif.hpp
+++ b/src/core/ee/vif.hpp
@@ -26,7 +26,7 @@ enum VIF_STALL
     STALL_IBIT = 1,
     STALL_MSKPATH3 = 2,
     STALL_STOP = 4,
-    STALL_WAIT = 8
+    STALL_DIRECT = 8
 };
 
 struct MPG_Command

--- a/src/core/ee/vif.hpp
+++ b/src/core/ee/vif.hpp
@@ -25,7 +25,8 @@ enum VIF_STALL
 {
     STALL_IBIT = 1,
     STALL_MSKPATH3 = 2,
-    STALL_STOP = 4
+    STALL_STOP = 4,
+    STALL_WAIT = 8
 };
 
 struct MPG_Command

--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -938,7 +938,7 @@ void Emulator::write128(uint32_t address, uint128_t value)
             vif1.feed_DMA(value);
             return;
         case 0x10006000:
-            gif.send_PATH3(value);
+            gif.send_PATH3_FIFO(value);
             return;
         case 0x10007010:
             ipu.write_FIFO(value);

--- a/src/core/gif.cpp
+++ b/src/core/gif.cpp
@@ -16,7 +16,6 @@ void GraphicsInterface::reset()
     path[3].current_tag.data_left = 0;
     active_path = 0;
     path_queue = 0;
-    intermittent_active = false;
     path_status[0] = 4;
     path_status[1] = 4;
     path_status[2] = 4;
@@ -29,6 +28,7 @@ void GraphicsInterface::reset()
     path3_mode_masked = false;
     path3_dma_waiting = false;
     gif_temporary_stop = false;
+    outputting_path = false;
 }
 
 uint32_t GraphicsInterface::read_STAT()
@@ -50,7 +50,7 @@ uint32_t GraphicsInterface::read_STAT()
     reg |= ((path_queue & (1 << 1)) != 0) << 8;
 
     //OPH
-    reg |= (active_path != 0) << 9;
+    reg |= outputting_path << 9;
 
     //APATH
     reg |= active_path << 10;
@@ -62,7 +62,7 @@ uint32_t GraphicsInterface::read_STAT()
     if (FIFO.size())
         reg |= FIFO.size() << 24;
     else
-        reg |= ((active_path == 3 || (path_queue & (1<<3))) * 16) << 24;
+        reg |= (((active_path == 3 || (path_queue & (1<<3))) && outputting_path) * 16) << 24;
     //printf("[GIF] Read GIF_STAT: $%08X\n", reg);
     return reg;
 }
@@ -211,6 +211,7 @@ void GraphicsInterface::feed_GIF(uint128_t data)
     //printf("[GIF] Data: $%08X_%08X_%08X_%08X\n", data._u32[3], data._u32[2], data._u32[1], data._u32[0]);
     uint64_t data1 = data._u64[0];
     uint64_t data2 = data._u64[1];
+    outputting_path = true;
     if (!path[active_path].current_tag.data_left)
     {
         //Read new GIFtag
@@ -391,15 +392,24 @@ void GraphicsInterface::request_PATH(int index, bool canInterruptPath3)
 void GraphicsInterface::deactivate_PATH(int index)
 {
     //printf("[GIF] PATH%d deactivated\n", index);
-
-    path_queue &= ~(1 << index);
-
-    //If for some reason the current path is still active (can happen with PATH3) kill it and check other paths
-    if (active_path == index)
+    if (path_status[index] == 4)
     {
-        active_path = 0;
-        clear_path_status(index);
-        arbitrate_paths();
+        path_queue &= ~(1 << index);
+
+        //If for some reason the current path is still active (can happen with PATH3) kill it and check other paths
+        if (active_path == index)
+        {
+            active_path = 0;
+            outputting_path = false;
+            clear_path_status(index);
+            arbitrate_paths();
+        }
+        //printf("Deactivated PATH%d Active path now %d Queued Path %x\n", index, active_path, path_queue);
+    }
+    else
+    {
+        //printf("[GIF] PATH%d deactivation failed, still in progress\n", index);
+        outputting_path = false;
     }
 
     //printf("Deactivated PATH%d Active path now %d Queued Path %x\n", index, active_path, path_queue);
@@ -472,6 +482,16 @@ void GraphicsInterface::send_PATH3(uint128_t data)
     }
 }
 
+void GraphicsInterface::send_PATH3_FIFO(uint128_t data)
+{
+    //printf("[GIF] Send PATH3 FIFO $%08X_%08X_%08X_%08X\n", data._u32[3], data._u32[2], data._u32[1], data._u32[0]);
+    if (FIFO.size() < 16)
+    {
+        //printf("Adding data to GIF FIFO (size: %d)\n", FIFO.size());
+        FIFO.push(data);
+    }
+}
+
 std::tuple<uint128_t, uint32_t>GraphicsInterface::read_GSFIFO()
 {
     return gs->request_gs_download();
@@ -488,6 +508,9 @@ void GraphicsInterface::flush_path3_fifo()
         if (!path3_dma_waiting || path3_masked(3))
         {
             //printf("GIF Deactivating PATH at FIFO flush end\n");
+            //Handle situation where FIFO just sends a NOP packet to the GIF unit (True Crime NY)
+            if (path_status[3] == 5)
+                path_status[3] = 4;
             deactivate_PATH(3);
         }
         else

--- a/src/core/gif.hpp
+++ b/src/core/gif.hpp
@@ -39,13 +39,13 @@ class GraphicsInterface
         std::queue<uint128_t> FIFO;
 
         uint8_t active_path;
+        bool outputting_path;
         uint8_t path_queue;
         //4 = Idle, Others match tag ID's
         uint8_t path_status[4];
         bool path3_vif_masked;
         bool path3_mode_masked;
         bool intermittent_mode;
-        bool intermittent_active;
         bool path3_dma_waiting;
         bool gif_temporary_stop;
 
@@ -88,6 +88,7 @@ class GraphicsInterface
         bool send_PATH1(uint128_t quad);
         void send_PATH2(uint32_t data[4]);
         void send_PATH3(uint128_t quad);
+        void send_PATH3_FIFO(uint128_t quad);
         std::tuple<uint128_t, uint32_t>read_GSFIFO();
 
         void intermittent_check();

--- a/src/core/serialize.cpp
+++ b/src/core/serialize.cpp
@@ -4,7 +4,7 @@
 
 #define VER_MAJOR 0
 #define VER_MINOR 0
-#define VER_REV 39
+#define VER_REV 41
 
 using namespace std;
 
@@ -643,6 +643,10 @@ void GraphicsInterface::load_state(ifstream &state)
     state.read((char*)&path3_vif_masked, sizeof(path3_vif_masked));
     state.read((char*)&internal_Q, sizeof(internal_Q));
     state.read((char*)&path3_dma_waiting, sizeof(path3_dma_waiting));
+    state.read((char*)&intermittent_mode, sizeof(intermittent_mode));
+    state.read((char*)&outputting_path, sizeof(outputting_path));
+    state.read((char*)&path3_mode_masked, sizeof(path3_mode_masked));
+    state.read((char*)&gif_temporary_stop, sizeof(gif_temporary_stop));
 }
 
 void GraphicsInterface::save_state(ofstream &state)
@@ -665,6 +669,10 @@ void GraphicsInterface::save_state(ofstream &state)
     state.write((char*)&path3_vif_masked, sizeof(path3_vif_masked));
     state.write((char*)&internal_Q, sizeof(internal_Q));
     state.write((char*)&path3_dma_waiting, sizeof(path3_dma_waiting));
+    state.write((char*)&intermittent_mode, sizeof(intermittent_mode));
+    state.write((char*)&outputting_path, sizeof(outputting_path));
+    state.write((char*)&path3_mode_masked, sizeof(path3_mode_masked));
+    state.write((char*)&gif_temporary_stop, sizeof(gif_temporary_stop));
 }
 
 void SubsystemInterface::load_state(ifstream &state)


### PR DESCRIPTION
…er path hasn't finished. Should fix some texture issues.

Fixes WRC glitching and Klonoa 2's character in the interpreter
Also added a vif stall wait when DIRECT cannot transfer to stop it looping unnecessarily