### PR TITLE
Set bit 7 of spu status reg on DMA pause

### DIFF
--- a/src/core/iop/spu.hpp
+++ b/src/core/iop/spu.hpp
@@ -39,7 +39,7 @@ struct Voice
 
 struct SPU_STAT
 {
-    bool DMA_finished;
+    bool DMA_ready;
     bool DMA_busy;
 };
 


### PR DESCRIPTION
This seems more like a DMA_ready bit.

When asked to stop a transfer libsd turns off the busy bit on the dma control
register which pauses the DMA transfer. It then proceeds to loop waiting
for bit 7 of spu status to turn to 1.

This is what's happening to Gregory Horror Show.