### PR TITLE
GS: Partially Implement and Log Undocumented Registers

### DIFF
--- a/src/core/gif.cpp
+++ b/src/core/gif.cpp
@@ -56,7 +56,7 @@ uint32_t GraphicsInterface::read_STAT()
     reg |= active_path << 10;
 
     //DIR
-    reg |= gs->read32_privileged(0x1040) << 12;
+    reg |= gs->get_busdir() << 12;
 
     //Quadword count - since we don't always emulate the FIFO, hack it to 16 if there's a transfer happening
     if (FIFO.size())

--- a/src/core/gs.cpp
+++ b/src/core/gs.cpp
@@ -256,6 +256,11 @@ void GraphicsSynthesizer::write32_privileged(uint32_t addr, uint32_t value)
     }
 }
 
+uint32_t GraphicsSynthesizer::get_busdir()
+{
+    return reg.BUSDIR;
+}
+
 uint32_t GraphicsSynthesizer::read32_privileged(uint32_t addr)
 {
     return reg.read32_privileged(addr);

--- a/src/core/gs.hpp
+++ b/src/core/gs.hpp
@@ -45,6 +45,7 @@ class GraphicsSynthesizer
 
         void set_CRT(bool interlaced, int mode, bool frame_mode);
 
+        uint32_t get_busdir();
         uint32_t read32_privileged(uint32_t addr);
         uint64_t read64_privileged(uint32_t addr);
         void write32_privileged(uint32_t addr, uint32_t value);

--- a/src/core/gsregisters.cpp
+++ b/src/core/gsregisters.cpp
@@ -193,7 +193,7 @@ void GS_REGISTERS::write64_privileged(uint32_t addr, uint64_t value)
             SIGLBLID.lbl_id = value >> 32;
             break;
         default:
-            printf("[GS_r] Unrecognized privileged write64 to reg $%04X: $%08lX_%08lX\n", addr, value >> 32, value & 0xFFFFFFFF);
+            Errors::die("[GS_r] Unrecognized privileged write64\nAddr: $%04X\nValue: $%08lX_%08lX\n", addr, value >> 32, value & 0xFFFFFFFF);
     }
 }
 
@@ -256,7 +256,7 @@ void GS_REGISTERS::write32_privileged(uint32_t addr, uint32_t value)
             SIGLBLID.sig_id = value;
             break;
         default:
-            printf("\n[GS_r] Unrecognized privileged write32 to reg $%04X: $%08X", addr, value);
+            Errors::die("[GS_r] Unrecognized privileged write32\nAddr: $%04X\nValue: $%08X", addr, value);
     }
 }
 

--- a/src/core/gsregisters.cpp
+++ b/src/core/gsregisters.cpp
@@ -73,6 +73,9 @@ void GS_REGISTERS::write64_privileged(uint32_t addr, uint64_t value)
                 SYNCH1.horizontal_front_porch, SYNCH1.horizontal_back_porch
             );
             break;
+        case 0x0050:
+            printf("[GS_r] Unimplemented privileged write64 to SYNCH2: $%08lX_%08lX\n", value >> 32, value & 0xFFFFFFFF);
+            break;
         case 0x0070:
             printf("[GS_r] Write DISPFB1: $%08lX_%08lX\n", value >> 32, value & 0xFFFFFFFF);
             DISPFB1.frame_base = (value & 0x1FF) * 2048;

--- a/src/core/gsregisters.cpp
+++ b/src/core/gsregisters.cpp
@@ -62,6 +62,9 @@ void GS_REGISTERS::write64_privileged(uint32_t addr, uint64_t value)
             else
                 deinterlace_method = BOB_DEINTERLACE;
             break;
+        case 0x0030: // this register is undocumented, it's fields are unknown
+            printf("[GS_r] Unimplemented privileged write64 to SRFSH: $%08lX_%08lX\n", value >> 32, value & 0xFFFFFFFF);
+            break;
         case 0x0040:
             SYNCH1.horizontal_front_porch = value & 0x7FF;
             SYNCH1.horizontal_back_porch = (value >> 11) & 0x7FF;

--- a/src/core/gsregisters.cpp
+++ b/src/core/gsregisters.cpp
@@ -4,7 +4,7 @@
 
 void GS_REGISTERS::write64_privileged(uint32_t addr, uint64_t value)
 {
-    addr &= 0xFFFF;
+    addr &= 0x13F0;
     switch (addr)
     {
         case 0x0000:
@@ -116,7 +116,7 @@ void GS_REGISTERS::write64_privileged(uint32_t addr, uint64_t value)
 
 void GS_REGISTERS::write32_privileged(uint32_t addr, uint32_t value)
 {
-    addr &= 0xFFFF;
+    addr &= 0x13F0;
     switch (addr)
     {
         case 0x0070:
@@ -185,12 +185,18 @@ uint32_t GS_REGISTERS::read32_privileged(uint32_t addr)
 
 uint64_t GS_REGISTERS::read64_privileged(uint32_t addr)
 {
-    addr &= 0xFFFF;
+    addr &= 0x13F0;
+
+    uint64_t reg = 0;
     switch (addr)
     {
-        case 0x1000:
-        {
-            uint64_t reg = 0;
+        case 0x1080:
+            reg |= SIGLBLID.sig_id;
+            reg |= (uint64_t)SIGLBLID.lbl_id << 32UL;
+            break;
+        default:
+            // All write only addresses return CSR
+            // but for completeness CSR is 0x1000
             reg |= CSR.SIGNAL_generated << 0;
             reg |= CSR.FINISH_generated << 1;
             reg |= CSR.VBLANK_generated << 3;
@@ -201,22 +207,9 @@ uint64_t GS_REGISTERS::read64_privileged(uint32_t addr)
             //Shadow Hearts needs this.
             reg |= 0x1B << 16;
             reg |= 0x55 << 24;
-            //printf("[GS_r] read64_privileged!: CSR = %08X\n", reg);
-            return reg;
-        }
-        case 0x1040:
-            return BUSDIR;
-        case 0x1080:
-        {
-            uint64_t reg = 0;
-            reg |= SIGLBLID.sig_id;
-            reg |= (uint64_t)SIGLBLID.lbl_id << 32UL;
-            return reg;
-        }
-        default:
-            printf("[GS_r] Unrecognized privileged read64 from $%04X\n", addr);
-            return 0;
     }
+
+    return reg;
 }
 
 bool GS_REGISTERS::write64(uint32_t addr, uint64_t value)

--- a/src/core/gsregisters.cpp
+++ b/src/core/gsregisters.cpp
@@ -136,6 +136,16 @@ void GS_REGISTERS::write64_privileged(uint32_t addr, uint64_t value)
             printf("MAGH: %d\n", DISPLAY2.magnify_x);
             printf("MAGV: %d\n", DISPLAY2.magnify_y);
             break;
+        case 0x00B0:
+            printf("[GS_r] Unimplemented privileged write64 to EXTBUF: $%08lX_%08lX\n", value >> 32, value & 0xFFFFFFFF);
+            break;
+        case 0x00C0:
+            printf("[GS_r] Unimplemented privileged write64 to EXTDATA: $%08lX_%08lX\n", value >> 32, value & 0xFFFFFFFF);
+            break;
+        case 0x00D0:
+            if (value & 0x1)
+                Errors::die("[GS_r] Feedback Write activated but not implemented");
+            break;
         case 0x00E0:
             printf("[GS_r] Write BGCOLOR: $%08lX\n", value);
             BGCOLOR = value & 0xFFFFFF;

--- a/src/core/gsregisters.cpp
+++ b/src/core/gsregisters.cpp
@@ -76,6 +76,27 @@ void GS_REGISTERS::write64_privileged(uint32_t addr, uint64_t value)
         case 0x0050:
             printf("[GS_r] Unimplemented privileged write64 to SYNCH2: $%08lX_%08lX\n", value >> 32, value & 0xFFFFFFFF);
             break;
+        case 0x0060:
+            SYNCV.vertical_front_porch = value & 0x3FF;
+            SYNCV.halflines_after_front_porch = (value >> 10) & 0x3FF;
+            SYNCV.vertical_back_porch = (value >> 20) & 0xFFF;
+            SYNCV.halflines_after_back_porch = (value >> 32) & 0x3FF;
+            SYNCV.halflines_with_video = (value >> 42) & 0x7FF;
+            SYNCV.halflines_with_vsync = (value >> 53) & 0x7FF;
+
+            printf("[GS_r] Unimplemented privileged write64 to SYNCV: $%08lX_%08lX\n"
+                "\tVertical Front Porch: %d\n"
+                "\tHalflines After Front Porch: %d\n"
+                "\tVertical Back Porch: %d\n"
+                "\tHalflines After Back Porch: %d\n"
+                "\tHalflines with Video: %d\n"
+                "\tHalflines with VSYNC: %d\n",
+                value >> 32, value & 0xFFFFFFFF,
+                SYNCV.vertical_front_porch, SYNCV.halflines_after_front_porch,
+                SYNCV.halflines_after_back_porch, SYNCV.halflines_after_back_porch,
+                SYNCV.halflines_with_video, SYNCV.halflines_with_vsync
+            );
+            break;
         case 0x0070:
             printf("[GS_r] Write DISPFB1: $%08lX_%08lX\n", value >> 32, value & 0xFFFFFFFF);
             DISPFB1.frame_base = (value & 0x1FF) * 2048;
@@ -322,6 +343,13 @@ void GS_REGISTERS::reset()
 
     SYNCH1.horizontal_back_porch = 0;
     SYNCH1.horizontal_front_porch = 0;
+
+    SYNCV.halflines_after_back_porch = 0;
+    SYNCV.halflines_after_front_porch = 0;
+    SYNCV.halflines_with_video = 0;
+    SYNCV.halflines_with_vsync = 0;
+    SYNCV.vertical_back_porch = 0;
+    SYNCV.vertical_front_porch = 0;
 
     DISPLAY1.x = 0;
     DISPLAY1.y = 0;

--- a/src/core/gsregisters.cpp
+++ b/src/core/gsregisters.cpp
@@ -62,6 +62,17 @@ void GS_REGISTERS::write64_privileged(uint32_t addr, uint64_t value)
             else
                 deinterlace_method = BOB_DEINTERLACE;
             break;
+        case 0x0040:
+            SYNCH1.horizontal_front_porch = value & 0x7FF;
+            SYNCH1.horizontal_back_porch = (value >> 11) & 0x7FF;
+
+            printf("[GS_r] Unimplemented privileged write64 to SYNCH1: $%08lX_%08lX\n"
+                "\tHorizontal Front Porch: %d\n"
+                "\tHorizontal Back Porch: %d\n",
+                value >> 32, value & 0xFFFFFFFF,
+                SYNCH1.horizontal_front_porch, SYNCH1.horizontal_back_porch
+            );
+            break;
         case 0x0070:
             printf("[GS_r] Write DISPFB1: $%08lX_%08lX\n", value >> 32, value & 0xFFFFFFFF);
             DISPFB1.frame_base = (value & 0x1FF) * 2048;
@@ -305,6 +316,9 @@ void GS_REGISTERS::reset()
     SMODE2.power_mode = 0;
 
     deinterlace_method = BOB_DEINTERLACE;
+
+    SYNCH1.horizontal_back_porch = 0;
+    SYNCH1.horizontal_front_porch = 0;
 
     DISPLAY1.x = 0;
     DISPLAY1.y = 0;

--- a/src/core/gsregisters.hpp
+++ b/src/core/gsregisters.hpp
@@ -16,7 +16,41 @@ struct PMODE_REG
     uint8_t ALP;
 };
 
-struct SMODE
+// SMODE1 (undocumented)
+//| Field  | Pos   | Format     | Notes                           |
+//| ------ | ----- | ---------- | ------------------------------- |
+//| RC     | 2:0   | int 0:3:0  | PLL Reference Divider           |
+//| LC     | 9:3   | int 0:7:0  | PLL Loop Divider                |
+//| T1248  | 11:10 | int 0:2:0  | PLL Output divider              |
+//| SLCK   | 12    | int 0:1:0  |                                 |
+//| CMOD   | 14:13 | int 0:2:0  | 0=VESA 1=RESERVED 2=NTSC, 3=PAL |
+//| EX     | 15    | int 0:1:0  |                                 |
+//| PRST   | 16    | int 0:1:0  | PLL Reset                       |
+//| SINT   | 17    | int 0:1:0  | PLL                             |
+//| XPCK   | 18    | int 0:1:0  |                                 |
+//| PCK2   | 20:19 | int 0:2:0? |                                 |
+//| SPML   | 24:21 | int 0:4:0? |                                 |
+//| GCONT  | 25    | int 0:1:0  | 0 = RGBYC, 1 = YCRCB            |
+//| PHS    | 26    | int 0:1:0  | HSync Output                    |
+//| PVS    | 27    | int 0:1:0  | VSync Output                    |
+//| PEHS   | 28    | int 0:1:0  |                                 |
+//| PEVS   | 29    | int 0:1:0  |                                 |
+//| CLKSEL | 31:30 | int 0:2:0? |                                 |
+//| NVCK   | 32    | int 0:1:0  |                                 |
+//| SLCK2  | 33    | int 0:1:0  |                                 |
+//| VCKSEL | 35:34 | int 0:2:0? |                                 |
+//| VHP    | 36    | int 0:1:0  |                                 |
+struct SMODE1_REG
+{
+    bool PLL_reset;
+    bool YCBCR_color;
+    uint8_t PLL_reference_divider;
+    uint8_t PLL_loop_divider;
+    uint8_t PLL_output_divider;
+    uint8_t color_system;
+};
+
+struct SMODE2_REG
 {
     bool interlaced;
     bool frame_mode;
@@ -79,7 +113,8 @@ struct GS_REGISTERS
 {
     //Privileged registers
     PMODE_REG PMODE;
-    SMODE SMODE2;
+    SMODE1_REG SMODE1;
+    SMODE2_REG SMODE2;
     DISPFB DISPFB1, DISPFB2;
     DISPLAY DISPLAY1, DISPLAY2;
     GS_IMR IMR;

--- a/src/core/gsregisters.hpp
+++ b/src/core/gsregisters.hpp
@@ -57,6 +57,20 @@ struct SMODE2_REG
     uint8_t power_mode;
 };
 
+// SYNCH1 (undocumented)
+//| Field | Pos   | Format      | Notes                  |
+//| ----- | ----- | ----------- | ---------------------- |
+//| HFP   | 10:0  | int 0:11:0? | Horizontal front porch |
+//| HBP   | 21:11 | int 0:11:0? | Horizontal back porch  |
+//| HSEQ  | 31:22 | int 0:10:0? |                        |
+//| HSVS  | 42:32 | int 0:11:0? |                        |
+//| HS    | ??    | int 0:??:0? |                        |
+struct SYNCH1_REG
+{
+    uint16_t horizontal_front_porch;
+    uint16_t horizontal_back_porch;
+};
+
 struct DISPFB
 {
     uint32_t frame_base;
@@ -115,6 +129,7 @@ struct GS_REGISTERS
     PMODE_REG PMODE;
     SMODE1_REG SMODE1;
     SMODE2_REG SMODE2;
+    SYNCH1_REG SYNCH1;
     DISPFB DISPFB1, DISPFB2;
     DISPLAY DISPLAY1, DISPLAY2;
     GS_IMR IMR;

--- a/src/core/gsregisters.hpp
+++ b/src/core/gsregisters.hpp
@@ -81,6 +81,25 @@ struct SYNCH1_REG
 //
 //};
 
+// SYNCV
+//| Field | Pos   | Format      | Notes                                                             |
+//| ----- | ----- | ----------- | ----------------------------------------------------------------- |
+//| VFP   | 9:0   | int 0:10:0? | Vertical front porch, halflines with color burst after video data |
+//| VFPE  | 19:10 | int 0:10:0? | Halflines without color burst after VFP                           |
+//| VBP   | 31:20 | int 0:12:0? | Vertical back porch, halflines with color burst after VFPE        |
+//| VBPE  | 41:32 | int 0:10:0? | Halflines without color burst after VBP                           |
+//| VDP   | 43:33 | int 0:11:0? | Halflines with video data                                         |
+//| VS    | 54:44 | int 0:11:0? | Halflines with VSYNC                                              |
+struct SYNCV_REG
+{
+    uint16_t vertical_front_porch;
+    uint16_t vertical_back_porch;
+    uint16_t halflines_after_front_porch;
+    uint16_t halflines_after_back_porch;
+    uint16_t halflines_with_video;
+    uint16_t halflines_with_vsync;
+};
+
 struct DISPFB
 {
     uint32_t frame_base;
@@ -140,6 +159,7 @@ struct GS_REGISTERS
     SMODE1_REG SMODE1;
     SMODE2_REG SMODE2;
     SYNCH1_REG SYNCH1;
+    SYNCV_REG SYNCV;
     DISPFB DISPFB1, DISPFB2;
     DISPLAY DISPLAY1, DISPLAY2;
     GS_IMR IMR;

--- a/src/core/gsregisters.hpp
+++ b/src/core/gsregisters.hpp
@@ -71,6 +71,16 @@ struct SYNCH1_REG
     uint16_t horizontal_back_porch;
 };
 
+// SYNCH2 (undocumented)
+//| Field | Pos  | Format      | Notes |
+//| ----- | ---- | ----------- | ----- |
+//| HF    | 10:0 | int 0:11:0? |       |
+//| HB    | 21:0 | int 0:11:0? |       |
+//struct SYNCH2_REG
+//{
+//
+//};
+
 struct DISPFB
 {
     uint32_t frame_base;

--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -460,7 +460,6 @@ void GraphicsSynthesizerThread::reset()
     pixels_transferred = 0;
     num_vertices = 0;
     frame_count = 0;
-    reg.deinterlace_method = BOB_DEINTERLACE;
 
     COLCLAMP = true;
 


### PR DESCRIPTION
- Implement reads return CSR when address is not readable and mirroring
- Partially implement and log some hidden registers (SMODE1, SYNCH1, SYNCH2, SYNCV, SRFSH)
- Die on unimplemented feedback write
- Die on unrecognized write to priv registers (want testing, may be temporary)

Games known to crash now:
- ~Seek and destroy (unrecog read64 to 0x1010)~
- Suffering (feedback write)

[CSR mirror test](https://github.com/PSI-Rockin/DobieStation/files/4536645/tests.zip)



