### PR TITLE
Disable EE JIT Branch Pipeline bug.

### DIFF
--- a/src/core/ee/ee_jittrans.cpp
+++ b/src/core/ee/ee_jittrans.cpp
@@ -76,8 +76,8 @@ IR::Block EE_JitTranslator::translate(EmotionEngine &ee)
         // todo: Insert a null op in cases where translated_instrs should be empty for more rigorous assertion testing?
         if (translated_instrs.size())
         {
-            /*branch_op = translated_instrs.back().is_jump();
-
+           branch_op = translated_instrs.back().is_jump();
+           /*
             //The EE has a bug in its pipelining logic that causes branches to be skipped in certain conditions.
             //They are as follows:
             // * The branch points to the start of a loop - forward branches are not affected

--- a/src/core/ee/ee_jittrans.cpp
+++ b/src/core/ee/ee_jittrans.cpp
@@ -76,8 +76,8 @@ IR::Block EE_JitTranslator::translate(EmotionEngine &ee)
         // todo: Insert a null op in cases where translated_instrs should be empty for more rigorous assertion testing?
         if (translated_instrs.size())
         {
-           branch_op = translated_instrs.back().is_jump();
-           /*
+            branch_op = translated_instrs.back().is_jump();
+            /*
             //The EE has a bug in its pipelining logic that causes branches to be skipped in certain conditions.
             //They are as follows:
             // * The branch points to the start of a loop - forward branches are not affected

--- a/src/core/ee/ee_jittrans.cpp
+++ b/src/core/ee/ee_jittrans.cpp
@@ -76,7 +76,7 @@ IR::Block EE_JitTranslator::translate(EmotionEngine &ee)
         // todo: Insert a null op in cases where translated_instrs should be empty for more rigorous assertion testing?
         if (translated_instrs.size())
         {
-            branch_op = translated_instrs.back().is_jump();
+            /*branch_op = translated_instrs.back().is_jump();
 
             //The EE has a bug in its pipelining logic that causes branches to be skipped in certain conditions.
             //They are as follows:
@@ -86,6 +86,11 @@ IR::Block EE_JitTranslator::translate(EmotionEngine &ee)
             // * Less than six instructions are present in the loop, including delay slot
             // * On EE revision #2.9 and later, the delay slot is not NOP
             // When all conditions are met, the branch is treated as if it were a NOP.
+
+            //Update - Refraction
+            //Me and Souzooka tested this on a real PS2 and couldn't get the bug to trigger with multiple scenarios
+            //So as far as I can tell this bug happens between VERY rarely to never.
+            //So Disabling for now, we can revisit this once we know how to trigger it.
 
             //Note that the branch delay slot has not been translated yet, so we use 5 instead of 6
             if (branch_op && ops_translated < 5)
@@ -98,7 +103,7 @@ IR::Block EE_JitTranslator::translate(EmotionEngine &ee)
                         translated_instrs.back().set_jump_dest(pc + 8);
                     }
                 }
-            }
+            }*/
 
             for (auto instr : translated_instrs)
                 instrs.push_back(instr);


### PR DESCRIPTION
Testing on the PS2 reveals this doesn't actually happen in several thousands of branches tested

> Loaded, host:C:\ps2dev\test (2).elf
> 
> start address 0x100108
> 
> gp address 00000000
> 
> Testing branch example 1:
>         li v1, 1
>     L1:
>         andi v0, v1, 0x1F
>         bnezl v0, L1
>         addiu v1, v1, 1
> 
> Test Result:  Correct, no branches skipped
> v0 = 0
> v1 = 32
> 
> Testing branch example 2:
>         li v1, 1
>     L1:
>         andi v0, v1, 0x1F
>         nop
>         bnezl v0, L1
>         addiu v1, v1, 1
> 
> Test Result: Correct no branches skipped
> v0 = 0
> v1 = 32
> 
> Testing branch example 3:
>         li v1, 10000
>     L1:
>         bnez v1, L1
>         addiu v1, -1
> 
> Test Result: Correct no branches skipped
> v0 = 76
> v1 = -1
> 
> Testing branch example 4:
>         la $v1, buf-4
>         move a1, zero
>         move s0, zero
>     L1:
>         addiu a1, a1, 1
>         addiu v1, v1, 4
>         addu s0, s0, a1
>         slti v0, a1, 80
>         bnez v0, L1
>         sw s0, 0(v1)
> 
> Test Result: Correct no branches skipped
> v0 = 0
> v1 = 1075004
> 
> Get Reboot Request From EE
> 
> ps2ip_ShutDown: Shutting down ps2ip-module
> 
> 0 kb/s

Attached is the ELF used for testing.  When compiling GCC did give a warning about "Loop too short for R5900", however upon inspecting the ELF it did not pad the loops, which would have nullified the tests.

[test (2).zip](https://github.com/PSI-Rockin/DobieStation/files/4565999/test.2.zip)

Also to note the ELF won't work on dobie as the ELF does not exit correctly.