### PR TITLE
EE JIT: Ensure RA doesn't get trashed for JAL(R)

### DIFF
--- a/src/core/ee/ee_jit64_gpr.cpp
+++ b/src/core/ee/ee_jit64_gpr.cpp
@@ -635,7 +635,8 @@ void EE_JIT64::jump(EmotionEngine& ee, IR::Instruction& instr)
     if (instr.get_is_link())
     {
         // Set the link register
-        emitter.MOV32_IMM_MEM(instr.get_return_addr(), REG_64::R15, offsetof(EmotionEngine, gpr) + get_gpr_offset(EE_NormalReg::ra));
+        REG_64 link = alloc_reg(ee, EE_NormalReg::ra, REG_TYPE::GPR, REG_STATE::WRITE);
+        emitter.MOV32_REG_IMM(instr.get_return_addr(), link);
     }
 }
 
@@ -649,7 +650,8 @@ void EE_JIT64::jump_indirect(EmotionEngine& ee, IR::Instruction& instr)
     if (instr.get_is_link())
     {
         // Set the link register
-        emitter.MOV32_IMM_MEM(instr.get_return_addr(), REG_64::R15, offsetof(EmotionEngine, gpr) + get_gpr_offset(EE_NormalReg::ra));
+        REG_64 link = alloc_reg(ee, EE_NormalReg::ra, REG_TYPE::GPR, REG_STATE::WRITE);
+        emitter.MOV32_REG_IMM(instr.get_return_addr(), link);
     }
 }
 


### PR DESCRIPTION
Previous implementation writes directly to RA in the EmotionEngine object. This PR changes this to allocate a host register to hold the value of RA.

The old implementation is flawed because a game can load a new value into RA. If RA is not allocated, it will be trashed by whatever value the game put into it when JAL(R) is executed, since the register allocator writes back all registers at the end of a block.

Fixes Dirge of Cerberus, potentially other games too.