### PR TITLE
Several VU timing and GS PATH fixes

### DIFF
--- a/src/core/ee/ee_jit64.cpp
+++ b/src/core/ee/ee_jit64.cpp
@@ -1765,7 +1765,7 @@ void ee_syscall_exception(EmotionEngine& ee)
 
 void vu0_start_program(VectorUnit& vu0, uint32_t addr)
 {
-    vu0.start_program(addr);
+    vu0.start_program(addr , 0);
 }
 
 uint32_t vu0_read_CMSAR0_shl3(VectorUnit& vu0)

--- a/src/core/ee/ee_jit64.cpp
+++ b/src/core/ee/ee_jit64.cpp
@@ -1765,7 +1765,7 @@ void ee_syscall_exception(EmotionEngine& ee)
 
 void vu0_start_program(VectorUnit& vu0, uint32_t addr)
 {
-    vu0.start_program(addr , 0);
+    vu0.start_program(addr, 0);
 }
 
 uint32_t vu0_read_CMSAR0_shl3(VectorUnit& vu0)

--- a/src/core/ee/emotion.cpp
+++ b/src/core/ee/emotion.cpp
@@ -713,7 +713,7 @@ void EmotionEngine::ctc(int cop_id, int reg, int cop_reg, uint32_t instruction)
                 clear_interlock();
             }
             if (cop_reg == 31)
-                vu1->start_program(bark << 3);
+                vu1->start_program(bark << 3, 0);
             else
                 vu0->ctc(cop_reg, bark);
             break;
@@ -1213,8 +1213,6 @@ void EmotionEngine::cop2_updatevu0()
 {
     if (!vu0->is_running())
     {
-        uint64_t cpu_cycles = get_cycle_count();
-        uint64_t cop2_cycles = get_cop2_last_cycle();
         uint32_t last_instr = read32(get_PC_now() - 4);
         uint32_t upper_instr = (last_instr >> 26);
         uint32_t cop2_instr = (last_instr >> 21) & 0x1F;
@@ -1222,15 +1220,12 @@ void EmotionEngine::cop2_updatevu0()
         //Always stall 1 VU cycle if the last op was LQC2, CTC2 or QMTC2
         if (upper_instr == 0x36 || (upper_instr == 0x12 && (cop2_instr == 0x5 || cop2_instr == 0x6)))
         {
-            vu0->cop2_updatepipes(1);
+            set_cycle_count(get_cycle_count() + 1);
         }
-
-        vu0->cop2_updatepipes(cpu_cycles - cop2_cycles);
-        set_cop2_last_cycle(cpu_cycles);
+        vu0->cop2_updatepipes();
     }
     else if (!vu0->is_interlocked())
     {
-        uint64_t current_count = (get_cycle_count() - cop2_last_cycle);
-        vu0->run_func(*vu0, current_count);
+        vu0->run_func(*vu0);
     }
 }

--- a/src/core/ee/emotion.hpp
+++ b/src/core/ee/emotion.hpp
@@ -57,7 +57,6 @@ class EmotionEngine
         Emulator* e;
 
         uint64_t cycle_count;
-        uint64_t cop2_last_cycle;
         int32_t cycles_to_run;
         uint64_t run_event;
 
@@ -112,8 +111,6 @@ class EmotionEngine
         uint64_t get_cycle_count();
         uint64_t get_cycle_count_goal();
         void set_cycle_count(uint64_t value);
-        uint64_t get_cop2_last_cycle();
-        void set_cop2_last_cycle(uint64_t value);
         void halt();
         void unhalt();
         void print_state();
@@ -249,16 +246,6 @@ inline uint64_t EmotionEngine::get_cycle_count_goal()
 inline void EmotionEngine::set_cycle_count(uint64_t value)
 {
     cycle_count = value;
-}
-
-inline uint64_t EmotionEngine::get_cop2_last_cycle()
-{
-    return cop2_last_cycle;
-}
-
-inline void EmotionEngine::set_cop2_last_cycle(uint64_t value)
-{
-    cop2_last_cycle = value;
 }
 
 inline void EmotionEngine::halt()

--- a/src/core/ee/emotion_vu0.cpp
+++ b/src/core/ee/emotion_vu0.cpp
@@ -1055,7 +1055,7 @@ void EmotionInterpreter::cop2_vcallms(EmotionEngine& cpu, uint32_t instruction)
     cpu.clear_interlock();
     //Sega Superstars Tennis is accurate down to the cycle when doing a QMFC2, so we need to account for the VCALLMS/R cycle also
     cpu.set_cycle_count(cpu.get_cycle_count() + 1);
-    vu0.start_program(imm);
+    vu0.start_program(imm, 0);
     cpu.set_cycle_count(cpu.get_cycle_count() - 1);
 }
 
@@ -1072,7 +1072,7 @@ void EmotionInterpreter::cop2_vcallmsr(EmotionEngine& cpu, uint32_t instruction)
     cpu.clear_interlock();
     //Sega Superstars Tennis is accurate down to the cycle when doing a QMFC2, so we need to account for the VCALLMS/R cycle also
     cpu.set_cycle_count(cpu.get_cycle_count() + 1);
-    vu0.start_program(vu0.read_CMSAR0() * 8);
+    vu0.start_program(vu0.read_CMSAR0() * 8, 0);
     cpu.set_cycle_count(cpu.get_cycle_count() - 1);
 }
 

--- a/src/core/ee/vif.cpp
+++ b/src/core/ee/vif.cpp
@@ -134,7 +134,7 @@ void VectorInterface::update(int cycles)
             {
                 if (vu->is_running())
                     return;
-                handle_wait_cmd(wait_cmd_value);
+                handle_wait_cmd(wait_cmd_value, cycles - (run_cycles >> 4));
             }
             if (wait_for_PATH3)
             {
@@ -166,7 +166,7 @@ void VectorInterface::update(int cycles)
             }
             else if (vif_cmd_status == VIF_TRANSFER)
             {
-                if(id)
+                if(id && gif->path_active(2, false))
                     gif->deactivate_PATH(2);
                 vif_cmd_status = VIF_WAIT;
             }
@@ -431,7 +431,7 @@ void VectorInterface::decode_cmd(uint32_t value)
     }
 }
 
-void VectorInterface::handle_wait_cmd(uint32_t value)
+void VectorInterface::handle_wait_cmd(uint32_t value, uint32_t cycles)
 {
     command = (value >> 24) & 0x7F;
     imm = value & 0xFFFF;
@@ -439,10 +439,10 @@ void VectorInterface::handle_wait_cmd(uint32_t value)
     {
         case 0x14:
         case 0x15:
-            MSCAL(imm * 8);
+            MSCAL(imm * 8, cycles);
             break;
         case 0x17:
-            MSCAL(vu->get_PC());
+            MSCAL(vu->get_PC(), cycles);
             break;
         default:
             break;
@@ -455,9 +455,9 @@ void VectorInterface::handle_wait_cmd(uint32_t value)
     
 }
 
-void VectorInterface::MSCAL(uint32_t addr)
+void VectorInterface::MSCAL(uint32_t addr, uint32_t cycles)
 {
-    vu->start_program(addr);
+    vu->start_program(addr, cycles);
 
     ITOP = ITOPS & mem_mask;
 

--- a/src/core/ee/vif.cpp
+++ b/src/core/ee/vif.cpp
@@ -134,7 +134,7 @@ void VectorInterface::update(int cycles)
             {
                 if (vu->is_running())
                     return;
-                handle_wait_cmd(wait_cmd_value, cycles - (run_cycles >> 4));
+                handle_wait_cmd(wait_cmd_value, (cycles - (run_cycles >> 2)) * 2);
             }
             if (wait_for_PATH3)
             {

--- a/src/core/ee/vif.hpp
+++ b/src/core/ee/vif.hpp
@@ -107,8 +107,8 @@ class VectorInterface
         int command_len;
         bool check_vif_stall(uint32_t value);
         void decode_cmd(uint32_t value);
-        void handle_wait_cmd(uint32_t value);
-        void MSCAL(uint32_t addr);
+        void handle_wait_cmd(uint32_t value, uint32_t cycles);
+        void MSCAL(uint32_t addr, uint32_t cycles);
         void init_UNPACK(uint32_t value);
         bool is_filling_write();
         void handle_UNPACK();

--- a/src/core/ee/vu.cpp
+++ b/src/core/ee/vu.cpp
@@ -175,6 +175,8 @@ void VectorUnit::reset()
     EFU_event_started = false;
     
     XGKICK_cycles = 0;
+    XGKICK_stall = false;
+    stalled_GIF_addr = 0;
 
     for (int i = 1; i < 32; i++)
     {

--- a/src/core/ee/vu.cpp
+++ b/src/core/ee/vu.cpp
@@ -160,13 +160,16 @@ void VectorUnit::reset()
 
     VU_JIT::reset(this);
     vumem_is_dirty = true; //assume we don't know the contents on reset
-    
+
+    PC = 0;
     finish_DIV_event = 0;
     finish_EFU_event = 0;
     new_Q_instance.u = 0;
     new_P_instance.u = 0;
     Q.u = 0;
     P.u = 0;
+    R.u = 0;
+    I.u = 0;
     DIV_event_started = false;
     EFU_event_started = false;
     
@@ -195,7 +198,6 @@ void VectorUnit::soft_reset()
     status = 0;
     status_pipe = 0;
     clip_flags = 0;
-    PC = 0;
     cycle_count = eecpu->get_cycle_count();
     running = false;
     tbit_stop = false;

--- a/src/core/ee/vu.cpp
+++ b/src/core/ee/vu.cpp
@@ -161,10 +161,6 @@ void VectorUnit::reset()
     VU_JIT::reset(this);
     vumem_is_dirty = true; //assume we don't know the contents on reset
     
-    transferring_GIF = false;
-    XGKICK_stall = false;
-    new_MAC_flags = 0;
-
     finish_DIV_event = 0;
     finish_EFU_event = 0;
     new_Q_instance.u = 0;
@@ -175,8 +171,9 @@ void VectorUnit::reset()
     EFU_event_started = false;
     
     XGKICK_cycles = 0;
-    XGKICK_stall = false;
     stalled_GIF_addr = 0;
+    transferring_GIF = false;
+    XGKICK_stall = false;
 
     for (int i = 1; i < 32; i++)
     {

--- a/src/core/ee/vu.cpp
+++ b/src/core/ee/vu.cpp
@@ -156,43 +156,25 @@ VectorUnit::VectorUnit(int id, Emulator* e, INTC* intc, EmotionEngine* cpu, Vect
 
 void VectorUnit::reset()
 {
-    status = 0;
-    status_pipe = 0;
-    clip_flags = 0;
-    PC = 0;
+    soft_reset();
+
     VU_JIT::reset(this);
-    //cycle_count = 1; //Set to 1 to prevent spurious events from occurring during execution
-    cycle_count = eecpu->get_cycle_count();
-    running = false;
-    tbit_stop = false;
     vumem_is_dirty = true; //assume we don't know the contents on reset
-    finish_on = false;
-    branch_on = false;
-    second_branch_pending = false;
-    secondbranch_PC = 0;
-    branch_delay_slot = 0;
-    ebit_delay_slot = 0;
+    
     transferring_GIF = false;
     XGKICK_stall = false;
     new_MAC_flags = 0;
-    new_Q_instance.u = 0;
+
     finish_DIV_event = 0;
-    pipeline_state[0] = 0;
-    pipeline_state[1] = 0;
+    finish_EFU_event = 0;
+    new_Q_instance.u = 0;
+    new_P_instance.u = 0;
+    Q.u = 0;
+    P.u = 0;
+    DIV_event_started = false;
+    EFU_event_started = false;
+    
     XGKICK_cycles = 0;
-
-    for (int i = 0; i < 4; i++) {
-        MAC_pipeline[i] = 0;
-        CLIP_pipeline[i] = 0;
-        ILW_pipeline[i] = 0;
-    }
-
-    flush_pipes();
-    int_branch_pipeline.reset();
-
-    int_backup_id = 0;
-    int_backup_reg = 0;
-    int_branch_delay = 0;
 
     for (int i = 1; i < 32; i++)
     {
@@ -224,8 +206,8 @@ void VectorUnit::soft_reset()
     secondbranch_PC = 0;
     branch_delay_slot = 0;
     ebit_delay_slot = 0;
-    
-    finish_DIV_event = 0;
+
+    new_MAC_flags = 0;
     pipeline_state[0] = 0;
     pipeline_state[1] = 0;
 
@@ -234,17 +216,9 @@ void VectorUnit::soft_reset()
         CLIP_pipeline[i] = 0;
         ILW_pipeline[i] = 0;
     }
-
+    
     decoder.reset();
     int_branch_pipeline.reset();
-
-    new_MAC_flags = 0;
-    new_Q_instance.u = 0;
-    new_P_instance.u = 0;
-    Q.u = 0;
-    P.u = 0;
-    DIV_event_started = false;
-    EFU_event_started = false;
 
     int_backup_id = 0;
     int_backup_reg = 0;

--- a/src/core/ee/vu.hpp
+++ b/src/core/ee/vu.hpp
@@ -207,6 +207,7 @@ class VectorUnit
         void stop();
         void stop_by_tbit();
         void reset();
+        void soft_reset();
 
         void backup_vf(bool newvf, int index);
         void restore_vf(bool newvf, int index);

--- a/src/core/ee/vu.hpp
+++ b/src/core/ee/vu.hpp
@@ -194,15 +194,15 @@ class VectorUnit
         void check_for_FMAC_stall();
         void check_for_COP2_FMAC_stall();
         void flush_pipes();
-        void cop2_updatepipes(int cycles);
+        void cop2_updatepipes();
         void handle_cop2_stalls();
 
-        void run(int cycles);
+        void run();
         void correct_jit_pipeline(int cycles);
-        void run_jit(int cycles);
+        void run_jit();
         void update_XGKick();
         void handle_XGKICK();
-        void start_program(uint32_t addr);
+        void start_program(uint32_t addr, uint32_t cycle_delay);
         void end_execution();
         void stop();
         void stop_by_tbit();
@@ -225,7 +225,7 @@ class VectorUnit
         template <typename T> void write_data(uint32_t addr, T data);
         template <typename T> void write_mem(uint32_t addr, T data);
 
-        std::function<void(VectorUnit&, int)> run_func;
+        std::function<void(VectorUnit&)> run_func;
 
         bool is_running();
         bool stopped_by_tbit();
@@ -447,7 +447,7 @@ inline void VectorUnit::write_mem(uint32_t addr, T data)
 
 inline bool VectorUnit::is_running()
 {
-    return running;
+    return running || (eecpu->get_cycle_count() < cycle_count);
 }
 
 inline bool VectorUnit::stopped_by_tbit()

--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -117,8 +117,8 @@ void Emulator::run()
         gif.run(bus_cycles);
         
         //VU's run at EE speed, however both maintain their own speed
-        vu0.run_func(vu0, ee_cycles);
-        vu1.run_func(vu1, ee_cycles);
+        vu0.run_func(vu0);
+        vu1.run_func(vu1);
 
         scheduler.process_events();
     }


### PR DESCRIPTION
remove COP2 cycle counting, now uses VU0 and EE cycles to sync
VU run functions no longer take cycles as a parameter
COP2 stalls now also stall the EE for the same number of cycles
start VU program now takes a cycle delay to account for DMA timings when using MSCAL
Keep VU's showing as "running" if the VU cycles overran the EE cycle count when ending a Micro Program, Solves some COP2 timing issues
stop PATH2 constantly deactivating itself (mainly cleans up logging)
Fix PATH1 requests from VU
Implements soft reset for FBRST calls. Only the VU is stopped and the control registers are reset, everything else is untouched.