### PR TITLE
SIFRPC Logging

### DIFF
--- a/src/core/ee/emotion.hpp
+++ b/src/core/ee/emotion.hpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <fstream>
 #include <functional>
+#include <list>
 #include "cop0.hpp"
 #include "cop1.hpp"
 
@@ -47,6 +48,13 @@ struct EE_OsdConfigParam
     /*16*/uint32_t language:5;
         /** timezone minutes offset from gmt */
     /*21*/uint32_t timezoneOffset:11;
+};
+
+struct SifRpcServer
+{
+    std::string name;
+    uint32_t module_id;
+    uint32_t client_ptr;
 };
 
 extern "C" uint8_t* exec_block_ee(EE_JIT64& jit, EmotionEngine& ee);
@@ -95,11 +103,15 @@ class EmotionEngine
 
         bool flush_jit_cache;
 
+        std::list<SifRpcServer> iop_rpc_servers;
         std::function<void(EmotionEngine&)> run_func;
 
         uint32_t get_paddr(uint32_t vaddr);
         void handle_exception(uint32_t new_addr, uint8_t code);
         void deci2call(uint32_t func, uint32_t param);
+
+        std::string sifrpc_lookup_module_name(uint32_t id);
+        void log_sifrpc(uint32_t dma_struct_ptr, int len);
     public:
         EmotionEngine(Cop0* cp0, Cop1* fpu, Emulator* e, VectorUnit* vu0, VectorUnit* vu1);
         static const char* REG(int id);

--- a/src/core/ee/emotion.hpp
+++ b/src/core/ee/emotion.hpp
@@ -13,6 +13,7 @@ class Emulator;
 class VectorUnit;
 class EE_JIT64;
 class EmotionEngine;
+class SubsystemInterface;
 
 //Handler used for Deci2Call (syscall 0x7C)
 struct Deci2Handler
@@ -50,14 +51,6 @@ struct EE_OsdConfigParam
     /*21*/uint32_t timezoneOffset:11;
 };
 
-struct SifRpcServer
-{
-    std::string name;
-    uint32_t module_id;
-    uint32_t client_ptr;
-    std::function<void(SifRpcServer& server, uint32_t fno, uint32_t buff, uint32_t buff_size)> rpc_func;
-};
-
 extern "C" uint8_t* exec_block_ee(EE_JIT64& jit, EmotionEngine& ee);
 
 class EmotionEngine
@@ -72,6 +65,7 @@ class EmotionEngine
 
         Cop0* cp0;
         Cop1* fpu;
+        SubsystemInterface* sif;
         VectorUnit* vu0;
         VectorUnit* vu1;
 
@@ -104,19 +98,15 @@ class EmotionEngine
 
         bool flush_jit_cache;
 
-        std::list<SifRpcServer> iop_rpc_servers;
         std::function<void(EmotionEngine&)> run_func;
 
         uint32_t get_paddr(uint32_t vaddr);
         void handle_exception(uint32_t new_addr, uint8_t code);
         void deci2call(uint32_t func, uint32_t param);
 
-        void sifrpc_register_server(std::string name, uint32_t module_id,
-                                    std::function<void(SifRpcServer& server,
-                                                       uint32_t fno, uint32_t buff, uint32_t buff_size)>);
         void log_sifrpc(uint32_t dma_struct_ptr, int len);
     public:
-        EmotionEngine(Cop0* cp0, Cop1* fpu, Emulator* e, VectorUnit* vu0, VectorUnit* vu1);
+        EmotionEngine(Cop0* cp0, Cop1* fpu, Emulator* e, SubsystemInterface* sif, VectorUnit* vu0, VectorUnit* vu1);
         static const char* REG(int id);
         static const char* SYSCALL(int id);
         void reset();

--- a/src/core/ee/emotion.hpp
+++ b/src/core/ee/emotion.hpp
@@ -55,6 +55,7 @@ struct SifRpcServer
     std::string name;
     uint32_t module_id;
     uint32_t client_ptr;
+    std::function<void(SifRpcServer& server, uint32_t fno, uint32_t buff, uint32_t buff_size)> rpc_func;
 };
 
 extern "C" uint8_t* exec_block_ee(EE_JIT64& jit, EmotionEngine& ee);
@@ -110,7 +111,9 @@ class EmotionEngine
         void handle_exception(uint32_t new_addr, uint8_t code);
         void deci2call(uint32_t func, uint32_t param);
 
-        std::string sifrpc_lookup_module_name(uint32_t id);
+        void sifrpc_register_server(std::string name, uint32_t module_id,
+                                    std::function<void(SifRpcServer& server,
+                                                       uint32_t fno, uint32_t buff, uint32_t buff_size)>);
         void log_sifrpc(uint32_t dma_struct_ptr, int len);
     public:
         EmotionEngine(Cop0* cp0, Cop1* fpu, Emulator* e, VectorUnit* vu0, VectorUnit* vu1);

--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -19,7 +19,7 @@
 Emulator::Emulator() :
     cdvd(&iop_intc, &iop_dma, &scheduler),
     cp0(&dmac),
-    cpu(&cp0, &fpu, this, &vu0, &vu1),
+    cpu(&cp0, &fpu, this, &sif, &vu0, &vu1),
     dmac(&cpu, this, &gif, &ipu, &sif, &vif0, &vif1, &vu0, &vu1),
     gif(&gs, &dmac),
     gs(&intc),
@@ -38,7 +38,7 @@ Emulator::Emulator() :
     vif1(&gif, &vu1, &intc, &dmac, 1),
     vu0(0, this, &intc, &cpu, &vu1),
     vu1(1, this, &intc, &cpu, &vu0),
-    sif(&iop_dma, &dmac)
+    sif(&cpu, &iop_dma, &dmac)
 {
     BIOS = nullptr;
     RDRAM = nullptr;

--- a/src/core/sif.cpp
+++ b/src/core/sif.cpp
@@ -4,8 +4,15 @@
 
 #include "iop/iop_dma.hpp"
 #include "ee/dmac.hpp"
+#include "ee/emotion.hpp"
 
-SubsystemInterface::SubsystemInterface(IOP_DMA* iop_dma, DMAC* dmac) : iop_dma(iop_dma), dmac(dmac)
+void default_rpc(SifRpcServer& server, uint32_t fno, uint32_t buffer, uint32_t size)
+{
+    printf("[SIFRPC] Unknown function $%08X called on %s ($%08X)\n", fno, server.name.c_str(), server.module_id);
+}
+
+SubsystemInterface::SubsystemInterface(EmotionEngine* ee, IOP_DMA* iop_dma, DMAC* dmac) :
+    ee(ee), iop_dma(iop_dma), dmac(dmac)
 {
 
 }
@@ -20,6 +27,94 @@ void SubsystemInterface::reset()
     msflag = 0;
     smflag = 0;
     control = 0;
+
+    rpc_servers.clear();
+    register_system_servers();
+}
+
+void SubsystemInterface::register_system_servers()
+{
+    auto default_rpc_lambda = [] (SifRpcServer& server, uint32_t fno, uint32_t buffer, uint32_t size)
+    {
+        default_rpc(server, fno, buffer, size);
+    };
+
+    auto iopheap_lambda = [=] (SifRpcServer& server, uint32_t fno, uint32_t buffer, uint32_t size)
+    {
+        switch (fno)
+        {
+            case 0x1:
+                //sceSifAllocIopHeap
+                printf("[SIFRPC] sceSifAllocIopHeap($%08X)\n", ee->read32(buffer));
+                break;
+            case 0x2:
+                //sceSifFreeIopHeap
+                printf("[SIFRPC] sceSifFreeIopHeap($%08X)\n", ee->read32(buffer));
+                break;
+            default:
+                default_rpc(server, fno, buffer, size);
+        }
+    };
+
+    auto cdncmd_lambda = [=] (SifRpcServer& server, uint32_t fno, uint32_t buffer, uint32_t size)
+    {
+        switch (fno)
+        {
+            case 0x1:
+                //sceCdRead
+            {
+                uint32_t lbn = ee->read32(buffer);
+                uint32_t sectors = ee->read32(buffer + 4);
+                uint32_t data = ee->read32(buffer + 8);
+                printf("[SIFRPC] sceCdRead(%d, %d, $%08X)\n", lbn, sectors, data);
+            }
+                break;
+            default:
+                default_rpc(server, fno, buffer, size);
+        }
+    };
+
+    sifrpc_register_server("FILEIO", 0x80000001, default_rpc_lambda);
+    sifrpc_register_server("IOPHEAP", 0x80000003, default_rpc_lambda);
+    sifrpc_register_server("LOADFILE", 0x80000006, default_rpc_lambda);
+    sifrpc_register_server("PAD1", 0x80000100, default_rpc_lambda);
+    sifrpc_register_server("PAD2", 0x80000101, default_rpc_lambda);
+    sifrpc_register_server("MCMAN", 0x80000400, default_rpc_lambda);
+    sifrpc_register_server("CDINIT", 0x80000592, default_rpc_lambda);
+    sifrpc_register_server("CDSCMD", 0x80000593, default_rpc_lambda);
+    sifrpc_register_server("CDNCMD", 0x80000595, cdncmd_lambda);
+    sifrpc_register_server("CDSEARCHFILE", 0x80000597, default_rpc_lambda);
+    sifrpc_register_server("CDDISKREADY", 0x8000059A, default_rpc_lambda);
+    sifrpc_register_server("SDREMOTE", 0x80000701, default_rpc_lambda);
+}
+
+void SubsystemInterface::sifrpc_register_server(std::string name, uint32_t module_id,
+                                                std::function<void (SifRpcServer &, uint32_t, uint32_t, uint32_t)>
+                                                func)
+{
+    SifRpcServer server;
+    server.name = name;
+    server.module_id = module_id;
+    server.client_ptr = 0;
+    server.rpc_func = func;
+    rpc_servers.push_back(server);
+}
+
+bool SubsystemInterface::sifrpc_bind(uint32_t module, uint32_t client)
+{
+    for (auto it = rpc_servers.begin(); it != rpc_servers.end(); it++)
+    {
+        if (it->module_id == module)
+        {
+            //Server found
+            printf("[SIFRPC] Client $%08X binding to %s ($%08X)\n", client, it->name.c_str(), module);
+            if (!it->client_ptr)
+                it->client_ptr = client;
+            return true;
+        }
+    }
+    //No server found, we will need to create a new one
+    return false;
 }
 
 void SubsystemInterface::write_SIF0(uint32_t word)
@@ -46,7 +141,7 @@ void SubsystemInterface::send_SIF0_junk(int count)
 
 void SubsystemInterface::write_SIF1(uint128_t quad)
 {
-    //printf("[SIF] Write SIF1: $%08X_%08X_%08X_%08X\n", quad._u32[3], quad._u32[2], quad._u32[1], quad._u32[0]);
+    printf("[SIF] Write SIF1: $%08X_%08X_%08X_%08X\n", quad._u32[3], quad._u32[2], quad._u32[1], quad._u32[0]);
     for (int i = 0; i < 4; i++)
         SIF1_FIFO.push(quad._u32[i]);
     iop_dma->set_DMA_request(IOP_SIF1);
@@ -153,4 +248,80 @@ void SubsystemInterface::set_control_IOP(uint32_t value)
         control &= ~bark;
     else
         control |= bark;
+}
+
+void SubsystemInterface::ee_log_sifrpc(uint32_t transfer_ptr, int len)
+{
+    if (len < 1)
+        return;
+
+    uint32_t call_ptr = transfer_ptr + (len * 0x10) - 0x10;
+    uint32_t pkt = ee->read32(call_ptr);
+    uint32_t rpc_func = ee->read32(pkt + 0x8);
+
+    switch (rpc_func)
+    {
+        case 0x80000002:
+            //INIT
+            printf("[SIFRPC] sceSifInitRpc\n");
+            for (auto it = rpc_servers.begin(); it != rpc_servers.end(); it++)
+            {
+                it->client_ptr = 0;
+            }
+            break;
+        case 0x80000003:
+            //RESET
+            printf("[SIFRPC] sceSifResetIop\n");
+            break;
+        case 0x80000009:
+            //BIND
+        {
+            printf("[SIFRPC] sceSifBindRpc\n");
+            uint32_t module_id = ee->read32(pkt + 0x20);
+            uint32_t client = ee->read32(pkt + 0x1C);
+            if (!sifrpc_bind(module_id, client))
+            {
+                //Unable to find server, so install a custom one.
+                sifrpc_register_server("CUSTOM", module_id,
+                                       [] (SifRpcServer& server, uint32_t fno, uint32_t buffer, uint32_t size)
+                                        { default_rpc(server, fno, buffer, size); });
+                sifrpc_bind(module_id, client);
+            }
+        }
+            break;
+        case 0x8000000A:
+            //CALL
+            printf("[SIFRPC] sceSifCallRpc\n");
+        {
+            uint32_t client = ee->read32(pkt + 0x1C);
+            uint32_t fno = ee->read32(pkt + 0x20);
+
+            for (auto it = rpc_servers.begin(); it != rpc_servers.end(); it++)
+            {
+                if (it->client_ptr == client)
+                {
+                    it->rpc_func(*it, fno, ee->read32(transfer_ptr), 0);
+
+                    //Check for FILEIO write - if fd is one, it's printing a message to STDOUT
+                    /*if (it->module_id == 0x80000001 && fno == 3)
+                    {
+                        uint32_t arg_ptr = read32(dma_struct_ptr);
+                        uint32_t fd = read32(arg_ptr);
+
+                        if (fd == 1)
+                        {
+                            //HLE writing to STDOUT
+                            e->ee_kputs(arg_ptr + 4);
+                        }
+                    }*/
+                    return;
+                }
+            }
+            printf("[SIFRPC] Unable to find server for client $%08X!\n", client);
+        }
+            break;
+        default:
+            printf("[SIFRPC] Unknown RPC function $%08X\n", rpc_func);
+            break;
+    }
 }

--- a/src/core/sif.cpp
+++ b/src/core/sif.cpp
@@ -75,7 +75,7 @@ void SubsystemInterface::register_system_servers()
     };
 
     sifrpc_register_server("FILEIO", 0x80000001, default_rpc_lambda);
-    sifrpc_register_server("IOPHEAP", 0x80000003, default_rpc_lambda);
+    sifrpc_register_server("IOPHEAP", 0x80000003, iopheap_lambda);
     sifrpc_register_server("LOADFILE", 0x80000006, default_rpc_lambda);
     sifrpc_register_server("PAD1", 0x80000100, default_rpc_lambda);
     sifrpc_register_server("PAD2", 0x80000101, default_rpc_lambda);
@@ -141,7 +141,7 @@ void SubsystemInterface::send_SIF0_junk(int count)
 
 void SubsystemInterface::write_SIF1(uint128_t quad)
 {
-    printf("[SIF] Write SIF1: $%08X_%08X_%08X_%08X\n", quad._u32[3], quad._u32[2], quad._u32[1], quad._u32[0]);
+    //printf("[SIF] Write SIF1: $%08X_%08X_%08X_%08X\n", quad._u32[3], quad._u32[2], quad._u32[1], quad._u32[0]);
     for (int i = 0; i < 4; i++)
         SIF1_FIFO.push(quad._u32[i]);
     iop_dma->set_DMA_request(IOP_SIF1);


### PR DESCRIPTION
This PR logs commands sent to the IOP via SIF. An SIF server is registered with a name, a module ID, and a lambda. Several system servers, such as LOADFILE, are registered on reset, but the system is flexible enough to register servers in custom modules games have. The lambda given to the server allows logging the names of specific server functions, as well as performing other functionality like intercepting stdout writes.

For details on the SIFRPC protocol, see [ps2tek.](https://psi-rockin.github.io/ps2tek/#sifrpcbasics)