### PR TITLE
GS: Limit CLUT reloads to number of entries in palette

### DIFF
--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -3980,6 +3980,9 @@ void GraphicsSynthesizerThread::clut_CSM2_lookup(uint8_t entry, RGBAQ_REG &tex_c
 void GraphicsSynthesizerThread::reload_clut(GSContext& context)
 {
     int eight_bit = false;
+    bool reload = false;
+    uint32_t clut_addr = context.tex0.CLUT_base;
+
     switch (context.tex0.format)
     {
         case 0x13: //8-bit textures
@@ -3997,12 +4000,6 @@ void GraphicsSynthesizerThread::reload_clut(GSContext& context)
             eight_bit = true;
             break;
     }
-
-    uint32_t clut_addr = context.tex0.CLUT_base;
-    uint32_t cache_addr = context.tex0.CLUT_offset;
-    uint32_t offset = (context.tex0.CLUT_offset / (context.tex0.CLUT_format ? 2 : 4));
-
-    bool reload = false;
 
     switch (context.tex0.CLUT_control)
     {
@@ -4031,13 +4028,18 @@ void GraphicsSynthesizerThread::reload_clut(GSContext& context)
             return;
     }
 
-    int entries = (eight_bit) ? 256 : 16;
-    int max_entries = (context.tex0.CLUT_format < 0x2 ? 256 : 512);
-
     if (reload)
     {
         printf("[GS_t] Reloading CLUT cache!\n");
-        for (int i = offset; i < max_entries; i++)
+
+        uint32_t cache_addr = context.tex0.CLUT_offset;
+        uint32_t offset = (context.tex0.CLUT_offset / (context.tex0.CLUT_format ? 2 : 4));
+        uint32_t entries = (eight_bit) ? 256 : 16;
+        uint32_t max_entries = (context.tex0.CLUT_format < 0x2 ? 256 : 512);
+
+        max_entries = std::min(max_entries, offset + entries);
+
+        for (uint32_t i = offset; i < max_entries; i++)
         {
             if (context.tex0.use_CSM2)
             {


### PR DESCRIPTION
Will also be clamped to the end of the CLUT memory if it exceeds it
Slight tidy up of the CLUT code to put all the variables together