### PR TITLE
EE JIT: Fix some incorrect instructions

### DIFF
--- a/src/core/ee/ee_jit64_fpu.cpp
+++ b/src/core/ee/ee_jit64_fpu.cpp
@@ -362,9 +362,12 @@ void EE_JIT64::floating_point_subtract(EmotionEngine& ee, IR::Instruction& instr
     }
     else if (dest == source2)
     {
-        emitter.SUBSS(source, dest);
-        emitter.load_addr((uint64_t)&FPU_MASK_NEG[0], REG_64::RAX);
-        emitter.PXOR_XMM_FROM_MEM(REG_64::RAX, dest);
+        // Would technically be nicer to do a backwards SUB and Negate, but this causes bugs in some situations
+        REG_64 XMM0 = lalloc_xmm_reg(ee, 0, REG_TYPE::XMMSCRATCHPAD, REG_STATE::SCRATCHPAD);
+        emitter.MOVAPS_REG(source, XMM0);
+        emitter.SUBSS(dest, XMM0);
+        emitter.MOVAPS_REG(XMM0, dest);
+        free_xmm_reg(ee, XMM0);
     }
     else
     {

--- a/src/core/ee/ee_jit64_fpu.cpp
+++ b/src/core/ee/ee_jit64_fpu.cpp
@@ -159,6 +159,8 @@ void EE_JIT64::floating_point_divide(EmotionEngine& ee, IR::Instruction& instr)
     emitter.MOVD_FROM_XMM(source, REG_64::RAX);
     emitter.MOVD_FROM_XMM(source2, R15);
     emitter.XOR32_REG(R15, REG_64::RAX);
+    emitter.AND32_REG_IMM(0x80000000, REG_64::RAX);
+    emitter.OR32_REG_IMM(0x7F7FFFFF, REG_64::RAX);
     emitter.MOVD_TO_XMM(REG_64::RAX, dest);
     uint8_t *exit = emitter.JMP_NEAR_DEFERRED();
 

--- a/src/core/ee/ee_jit64_gpr.cpp
+++ b/src/core/ee/ee_jit64_gpr.cpp
@@ -1392,29 +1392,36 @@ void EE_JIT64::store_doubleword_left(EmotionEngine& ee, IR::Instruction& instr)
     else
         emitter.MOV32_REG(dest, addr);
     emitter.MOV32_REG(addr, addr_backup);
+    emitter.AND32_REG_IMM(0x7, addr_backup);
     emitter.AND32_REG_IMM(~0x7, addr);
+
     prepare_abi((uint64_t)&ee);
     prepare_abi_reg(addr);
     call_abi_func((uint64_t)ee_read64);
+
+    emitter.MOV64_MR(source, addr);
+    emitter.CMP16_IMM(0x7, addr_backup);
+    uint8_t* no_shift = emitter.JCC_NEAR_DEFERRED(ConditionCode::E);
+
     emitter.MOV32_REG(addr_backup, RCX);
     emitter.AND32_REG_IMM(0x7, RCX);
     emitter.SHL32_REG_IMM(0x3, RCX);
     emitter.XOR16_REG_IMM(56, RCX);
-    emitter.MOV64_MR(source, addr);
     emitter.SHR64_CL(addr);
     emitter.SUB16_REG_IMM(64, RCX);
     emitter.NEG16(RCX);
-    emitter.MOV32_REG_IMM(0x3F, addr_backup);
-    emitter.CMP16_IMM(0x40, RCX);
-    emitter.CMOVCC16_REG(ConditionCode::E, addr_backup, RCX);
     emitter.SHR64_CL(REG_64::RAX);
     emitter.SHL64_CL(REG_64::RAX);
     emitter.OR64_REG(REG_64::RAX, addr);
+
+    emitter.set_jump_dest(no_shift);
+
     if (offset)
         emitter.LEA32_M(dest, addr_backup, offset);
     else
         emitter.MOV32_REG(dest, addr_backup);
     emitter.AND32_REG_IMM(~0x7, addr_backup);
+
     prepare_abi((uint64_t)&ee);
     prepare_abi_reg(addr_backup);
     prepare_abi_reg(addr);
@@ -1438,28 +1445,35 @@ void EE_JIT64::store_doubleword_right(EmotionEngine& ee, IR::Instruction& instr)
     else
         emitter.MOV32_REG(dest, addr);
     emitter.MOV32_REG(addr, addr_backup);
+    emitter.AND32_REG_IMM(0x7, addr_backup);
     emitter.AND32_REG_IMM(~0x7, addr);
+
     prepare_abi((uint64_t)&ee);
     prepare_abi_reg(addr);
     call_abi_func((uint64_t)ee_read64);
+
+    emitter.MOV64_MR(source, addr);
+    emitter.CMP16_IMM(0, addr_backup);
+    uint8_t* no_shift = emitter.JCC_NEAR_DEFERRED(ConditionCode::E);
+
     emitter.MOV32_REG(addr_backup, RCX);
     emitter.AND32_REG_IMM(0x7, RCX);
     emitter.SHL32_REG_IMM(0x3, RCX);
-    emitter.MOV64_MR(source, addr);
     emitter.SHL64_CL(addr);
     emitter.SUB16_REG_IMM(64, RCX);
     emitter.NEG16(RCX);
-    emitter.MOV32_REG_IMM(0x3F, addr_backup);
-    emitter.CMP16_IMM(0x40, RCX);
-    emitter.CMOVCC16_REG(ConditionCode::E, addr_backup, RCX);
     emitter.SHL64_CL(REG_64::RAX);
     emitter.SHR64_CL(REG_64::RAX);
     emitter.OR64_REG(REG_64::RAX, addr);
+
+    emitter.set_jump_dest(no_shift);
+
     if (offset)
         emitter.LEA32_M(dest, addr_backup, offset);
     else
         emitter.MOV32_REG(dest, addr_backup);
     emitter.AND32_REG_IMM(~0x7, addr_backup);
+
     prepare_abi((uint64_t)&ee);
     prepare_abi_reg(addr_backup);
     prepare_abi_reg(addr);


### PR DESCRIPTION
Fix SDL/SDR when memory is completely shifted out
Fix DIV_S not handling Divide by Zero correctly
Fix SUB_S handling of FD == FT

Fixes bouncing in Spongebob Squarepants
Fixes bad colours in CoD 2
Fixes black screen in Marvel Vs Capcom 2