### PR TITLE
GS: Fix accidental double asserted IRQ on double SIGNAL

### DIFF
--- a/src/core/gif.cpp
+++ b/src/core/gif.cpp
@@ -401,7 +401,10 @@ void GraphicsInterface::deactivate_PATH(int index)
     {
         //printf("[GIF] PATH%d deactivation failed, still in progress\n", index);
         if (active_path == index)
+        {
+            gs->set_CSR_FIFO(0x1);
             outputting_path = false;
+        }
     }
 
     //printf("Deactivated PATH%d Active path now %d Queued Path %x\n", index, active_path, path_queue);

--- a/src/core/gs.cpp
+++ b/src/core/gs.cpp
@@ -211,9 +211,9 @@ void GraphicsSynthesizer::write64(uint32_t addr, uint64_t value)
     //We need a check for SIGNAL here so that we can fire the interrupt as soon as possible
     if (addr == 0x60)
     {
-        if (reg.CSR.SIGNAL_generated)
+        if (reg.CSR.SIGNAL_generated && !reg.CSR.SIGNAL_stall)
         {
-            if(!reg.IMR.signal)
+            if (!reg.IMR.signal)
                 intc->assert_IRQ((int)Interrupt::GS);
             else
                 reg.CSR.SIGNAL_irq_pending = true;


### PR DESCRIPTION
Correctly "empty" the GS CSR FIFO when a path is stopped before it's complete