### PR TITLE
IPU: Perform an interrupt on IPU_CTRL Reset.

### DIFF
--- a/src/core/ee/ipu/ipu.cpp
+++ b/src/core/ee/ipu/ipu.cpp
@@ -1311,11 +1311,13 @@ void ImageProcessingUnit::write_control(uint32_t value)
     ctrl.picture_type = (value >> 24) & 0x7;
     if (value & (1 << 30))
     {
-        ctrl.busy = false;
-        command_decoding = false;
         command = 0;
         in_FIFO.reset();
         out_FIFO.reset();
+        // Note: A control reset does a forced command end, meaning it will force the procedure of a command stopping
+        // even if there is no command currently active, causing an interrupt to the core.
+        // Fightbox relies on this behaviour to boot and play its first two videos.
+        finish_command();
     }
 }
 


### PR DESCRIPTION
As explained in the file, doing this reset performs a forced command end, meaning the IPU will run through the procedure of ending any command running and telling the core that it is done, even if there is no command currently active.
Fixes Fightbox