### PR TITLE
Detect ps1 disks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ Makefile*
 *.snp
 *_log.txt
 *.log
+.vscode/settings.json

--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -317,6 +317,16 @@ void Emulator::fast_boot()
 {
     if (skip_BIOS_hack == LOAD_DISC)
     {
+
+        if (cdvd.read_disc_type() != CDVD_DISC_PS2DVD)
+        {
+            if (cdvd.read_disc_type() != CDVD_DISC_PS2CD)
+            {
+                set_skip_BIOS_hack(SKIP_HACK::NONE);
+                return;
+            }
+        }
+
         //We need to find the string "rom0:OSDSYS" and replace it with the disc's executable.
         std::string path = cdvd.get_ps2_exec_path();
 

--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -325,7 +325,6 @@ void Emulator::fast_boot()
                 return;
             }
         }
-
         //We need to find the string "rom0:OSDSYS" and replace it with the disc's executable.
         std::string path = cdvd.get_ps2_exec_path();
 

--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -317,7 +317,6 @@ void Emulator::fast_boot()
 {
     if (skip_BIOS_hack == LOAD_DISC)
     {
-
         if (cdvd.read_disc_type() != CDVD_DISC_PS2DVD)
         {
             if (cdvd.read_disc_type() != CDVD_DISC_PS2CD)

--- a/src/core/iop/cdvd/cdvd.cpp
+++ b/src/core/iop/cdvd/cdvd.cpp
@@ -272,6 +272,7 @@ bool CDVD_Drive::load_disc(const char *name, CDVD_CONTAINER a_container)
 
     if (!container->open(name)) // No Filename, No disc.
     {
+        printf("No Disk Inserted \n");
         disc_type = CDVD_DISC_NONE;
         return false;
     }
@@ -311,41 +312,39 @@ bool CDVD_Drive::load_disc(const char *name, CDVD_CONTAINER a_container)
     if ((volume_size * LBA) <= 681574400 || path_table_sector != 257)
     {
         uint32_t cnf_size;
-        std::string cnf = (char*)read_file("SYSTEM.CNF;1", cnf_size);          
-        if (cnf == "")
+        
+        std::string cnf;
+
+        if (char* temp = (char*)read_file("SYSTEM.CNF;1", cnf_size))
+            cnf = temp;
+
+        else 
         {
             printf("Non PlayStation Disc inserted \n");
             disc_type = CDVD_DISC_ILL;
             return true;
         }
 
-      cnf.erase(std::remove_if(cnf.begin(), cnf.end(), ::isspace), cnf.end());
+        cnf.erase(std::remove_if(cnf.begin(), cnf.end(), ::isspace), cnf.end());
 
-        std::string pos = strstr(cnf.c_str(), "BOOT2");
-
-        if (pos.c_str() == nullptr)
+        if (cnf.find("BOOT2") != std::string::npos)
         {
-            pos = strstr(cnf.c_str(), "BOOT"); // PS2 disk
+            printf("PlayStation 2 Detected \n");
+            disc_type = CDVD_DISC_PS2CD;
+            return true;
+        }
 
-            if (pos.c_str() == nullptr)
-            {
-                printf("Non PlayStation Disc inserted \n");
-                disc_type = CDVD_DISC_ILL;
-                return true;
-            }
-
-            else
-            {              
-                printf("Detected PS1 \n");
-                disc_type = CDVD_DISC_PSCD;
-                return true;   
-            }
+        if(cnf.find("BOOT") != std::string::npos)
+        {
+             printf("PlayStation 1 Detected \n");
+             disc_type = CDVD_DISC_PSCD;
+             return true;   
         }
 
         else
         {
-            printf("Detected PS2 \n");
-            disc_type = CDVD_DISC_PS2CD;
+            printf("Non PlayStation Disc inserted \n");
+            disc_type = CDVD_DISC_ILL;
             return true;
         }
     }

--- a/src/core/iop/cdvd/cdvd.cpp
+++ b/src/core/iop/cdvd/cdvd.cpp
@@ -269,8 +269,12 @@ bool CDVD_Drive::load_disc(const char *name, CDVD_CONTAINER a_container)
             container = nullptr;
             return false;
     }
-    if (!container->open(name))
+
+    if (!container->open(name)) // No Filename, No disc.
+    {
+        disc_type = CDVD_DISC_NONE;
         return false;
+    }
 
     file_size = container->get_size();
 
@@ -319,7 +323,9 @@ bool CDVD_Drive::load_disc(const char *name, CDVD_CONTAINER a_container)
 
             if (pos == NULL)
             {
-                return false;
+                printf("Non PlayStation Disc inserted \n");
+                disc_type = CDVD_DISC_ILL;
+                return true;
             }
 
             else

--- a/src/core/iop/cdvd/cdvd.cpp
+++ b/src/core/iop/cdvd/cdvd.cpp
@@ -106,7 +106,7 @@ string CDVD_Drive::get_ps2_exec_path()
 string CDVD_Drive::get_serial()
 {
 
-    if(disc_type == CDVD_DISC_PSCD)
+    if (disc_type == CDVD_DISC_PSCD)
     {
         return "PlayStaion 1 Disc";
     }
@@ -275,7 +275,6 @@ bool CDVD_Drive::load_disc(const char *name, CDVD_CONTAINER a_container)
             container = nullptr;
             return false;
     }
-
     if (!container->open(name)) // No Filename, No disc.
     {
         printf("No Disk Inserted \n");
@@ -340,7 +339,7 @@ bool CDVD_Drive::load_disc(const char *name, CDVD_CONTAINER a_container)
             return true;
         }
 
-        if(cnf.find("BOOT") != std::string::npos || cnf.find("PSX.EXE") != std::string::npos)
+        if (cnf.find("BOOT") != std::string::npos || cnf.find("PSX.EXE") != std::string::npos)
         {
              printf("PlayStation 1 CD Detected \n");
              disc_type = CDVD_DISC_PSCD;
@@ -357,8 +356,36 @@ bool CDVD_Drive::load_disc(const char *name, CDVD_CONTAINER a_container)
     
     else
     {
-        printf("PlayStation 2 DVD Detected \n");
-        disc_type = CDVD_DISC_PS2DVD; 
+        uint32_t cnf_size;
+        
+        std::string cnf;
+
+        if (char* temp = (char*)read_file("SYSTEM.CNF;1", cnf_size))
+            cnf = temp;
+
+        else 
+        {
+            printf("Non PlayStation Disc inserted \n");
+            disc_type = CDVD_DISC_ILL;
+            return true;
+        }
+
+        cnf.erase(std::remove_if(cnf.begin(), cnf.end(), ::isspace), cnf.end());
+
+        if (cnf.find("BOOT2") != std::string::npos)
+        {
+            printf("PlayStation 2 DVD Detected \n");
+            disc_type = CDVD_DISC_PS2DVD;
+            return true;
+        }
+
+        else 
+        {
+            printf("Non PlayStation Disc inserted \n");
+            disc_type = CDVD_DISC_ILL;
+            return true;
+        }
+         
     }
 
     printf("%s Detected\n", disc_type == CDVD_DISC_PS2CD ? "CD" : "DVD");

--- a/src/core/iop/cdvd/cdvd.cpp
+++ b/src/core/iop/cdvd/cdvd.cpp
@@ -315,11 +315,11 @@ bool CDVD_Drive::load_disc(const char *name, CDVD_CONTAINER a_container)
     if (!cnf)
         return "h";
 
-        char* pos = strstr(cnf, "BOOT ");
+        char* pos = strstr(cnf, "BOOT2");
 
         if (pos == NULL)
         {
-            pos = strstr(cnf, "BOOT2 "); // PS2 disk
+            pos = strstr(cnf, "BOOT"); // PS2 disk
 
             if (pos == NULL)
             {
@@ -330,16 +330,16 @@ bool CDVD_Drive::load_disc(const char *name, CDVD_CONTAINER a_container)
 
             else
             {              
-                disc_type = CDVD_DISC_PS2CD;
+                printf("Detected PS1 \n");
+                disc_type = CDVD_DISC_PSCD;
                 return true;   
             }
         }
 
         else
         {
-
-            printf("Detected PS1 \n");
-            disc_type = CDVD_DISC_PSCD;
+            printf("Detected PS2 \n");
+            disc_type = CDVD_DISC_PS2CD;
             return true;
         }
     }

--- a/src/core/iop/cdvd/cdvd.cpp
+++ b/src/core/iop/cdvd/cdvd.cpp
@@ -311,17 +311,23 @@ bool CDVD_Drive::load_disc(const char *name, CDVD_CONTAINER a_container)
     if ((volume_size * LBA) <= 681574400 || path_table_sector != 257)
     {
         uint32_t cnf_size;
-        char* cnf = (char*)read_file("SYSTEM.CNF;1", cnf_size);          
-    if (!cnf)
-        return "h";
-
-        char* pos = strstr(cnf, "BOOT2");
-
-        if (pos == NULL)
+        std::string cnf = (char*)read_file("SYSTEM.CNF;1", cnf_size);          
+        if (cnf == "")
         {
-            pos = strstr(cnf, "BOOT"); // PS2 disk
+            printf("Non PlayStation Disc inserted \n");
+            disc_type = CDVD_DISC_ILL;
+            return true;
+        }
 
-            if (pos == NULL)
+      cnf.erase(std::remove_if(cnf.begin(), cnf.end(), ::isspace), cnf.end());
+
+        std::string pos = strstr(cnf.c_str(), "BOOT2");
+
+        if (pos.c_str() == nullptr)
+        {
+            pos = strstr(cnf.c_str(), "BOOT"); // PS2 disk
+
+            if (pos.c_str() == nullptr)
             {
                 printf("Non PlayStation Disc inserted \n");
                 disc_type = CDVD_DISC_ILL;

--- a/src/core/iop/cdvd/cdvd.cpp
+++ b/src/core/iop/cdvd/cdvd.cpp
@@ -105,6 +105,12 @@ string CDVD_Drive::get_ps2_exec_path()
 
 string CDVD_Drive::get_serial()
 {
+
+    if(disc_type == CDVD_DISC_PSCD)
+    {
+        return "PlayStaion 1 Disc";
+    }
+
     if (!container->is_open())
         return "";
 
@@ -329,14 +335,14 @@ bool CDVD_Drive::load_disc(const char *name, CDVD_CONTAINER a_container)
 
         if (cnf.find("BOOT2") != std::string::npos)
         {
-            printf("PlayStation 2 Detected \n");
+            printf("PlayStation 2 CD Detected \n");
             disc_type = CDVD_DISC_PS2CD;
             return true;
         }
 
         if(cnf.find("BOOT") != std::string::npos || cnf.find("PSX.EXE") != std::string::npos)
         {
-             printf("PlayStation 1 Detected \n");
+             printf("PlayStation 1 CD Detected \n");
              disc_type = CDVD_DISC_PSCD;
              return true;   
         }
@@ -350,7 +356,10 @@ bool CDVD_Drive::load_disc(const char *name, CDVD_CONTAINER a_container)
     }
     
     else
+    {
+        printf("PlayStation 2 DVD Detected \n");
         disc_type = CDVD_DISC_PS2DVD; 
+    }
 
     printf("%s Detected\n", disc_type == CDVD_DISC_PS2CD ? "CD" : "DVD");
     printf("[CDVD] PVD LBA: $%08X\n", LBA);

--- a/src/core/iop/cdvd/cdvd.cpp
+++ b/src/core/iop/cdvd/cdvd.cpp
@@ -334,7 +334,7 @@ bool CDVD_Drive::load_disc(const char *name, CDVD_CONTAINER a_container)
             return true;
         }
 
-        if(cnf.find("BOOT") != std::string::npos)
+        if(cnf.find("BOOT") != std::string::npos || cnf.find("PSX.EXE") != std::string::npos)
         {
              printf("PlayStation 1 Detected \n");
              disc_type = CDVD_DISC_PSCD;

--- a/src/core/iop/cdvd/cdvd.cpp
+++ b/src/core/iop/cdvd/cdvd.cpp
@@ -107,7 +107,7 @@ string CDVD_Drive::get_serial()
 {
     if (disc_type == CDVD_DISC_PSCD)
     {
-        return "PlayStaion 1 Disc";
+        return "PlayStation 1 Disc";
     }
     if (!container->is_open())
         return "";

--- a/src/core/iop/cdvd/cdvd.hpp
+++ b/src/core/iop/cdvd/cdvd.hpp
@@ -3,6 +3,8 @@
 
 #include <fstream>
 #include <memory>
+#include <algorithm>
+#include <string.h>
 #include "cdvd_container.hpp"
 
 class IOP_INTC;


### PR DESCRIPTION
This is a pr to detect ps1 disks in dobiestation it adds an extra check in SYSTEM.CNF for BOOT (PS1 Game) over BOOT2 (ps2 game)