### PR TITLE
GS: Use LOD=K MipMap mode when using UV coords

### DIFF
--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -3527,7 +3527,7 @@ void GraphicsSynthesizerThread::calculate_LOD(TexLookupInfo &info)
 
     float K = current_ctx->tex1.K;
 
-    if (current_ctx->tex1.LOD_method == 0)
+    if (current_ctx->tex1.LOD_method == 0 && !current_PRMODE->use_UV)
     {
         if (info.vtx_color.q != 1.0f)
         {


### PR DESCRIPTION
Fixes Ratchet & Clank memcard screen