### PR TITLE
Small changes

### DIFF
--- a/src/core/ee/dmac.cpp
+++ b/src/core/ee/dmac.cpp
@@ -306,8 +306,8 @@ int DMAC::process_VIF1()
             else
             {
                 auto quad_data = vif1->readFIFO();
-                if (std::get<1>(quad_data))
-                    store128(channels[VIF1].address, std::get<0>(quad_data));
+                if (quad_data.second)
+                    store128(channels[VIF1].address, quad_data.first);
                 else
                 {
                     arbitrate();

--- a/src/core/ee/ee_jit64.cpp
+++ b/src/core/ee/ee_jit64.cpp
@@ -160,7 +160,7 @@ void EE_JIT64::emit_dispatcher()
 
     //First we need to make sure the pointer isn't NULL, which means no block has been recompiled.
     //If it is NULL, we go to the slow path.
-    emitter.CMP64_IMM(0, REG_64::RAX);
+    emitter.TEST64_REG(REG_64::RAX, REG_64::RAX);
     uint8_t* slow_path_dest1 = emitter.JCC_NEAR_DEFERRED(ConditionCode::E);
 
     //Compare current PC with the PC of the block

--- a/src/core/ee/ee_jit64_gpr.cpp
+++ b/src/core/ee/ee_jit64_gpr.cpp
@@ -514,9 +514,9 @@ void EE_JIT64::divide_word(EmotionEngine& ee, IR::Instruction &instr, bool hi)
     emitter.SETCC_REG(ConditionCode::L, REG_64::RAX);
     emitter.SHL8_REG_1(REG_64::RAX);
     emitter.DEC8(REG_64::RAX);
-    emitter.MOVSX8_TO_64(REG_64::RAX, REG_64::RAX);
+    emitter.MOVSX8_TO_64(REG_64::RAX, REG_64::RAX); // sign extend al into rax
     emitter.MOVSX32_TO_64(dividend, dividend);
-    emitter.MOVSX8_TO_64(REG_64::RAX, LO);
+    emitter.MOV64_MR(REG_64::RAX, LO); // store the previously extended al into lo
     emitter.MOVSX32_TO_64(dividend, HI);
 
     emitter.set_jump_dest(end_1);
@@ -1327,8 +1327,7 @@ void EE_JIT64::shift_right_logical_variable(EmotionEngine& ee, IR::Instruction& 
     // Alloc variable into RCX
     REG_64 RCX = lalloc_int_reg(ee, 0, REG_TYPE::INTSCRATCHPAD, REG_STATE::SCRATCHPAD, REG_64::RCX);
     REG_64 variable = alloc_reg(ee, instr.get_source2(), REG_TYPE::GPR, REG_STATE::READ);
-    emitter.MOV8_REG(variable, RCX);
-    emitter.AND8_REG_IMM(0x1F, RCX);
+    emitter.MOV8_REG(variable, RCX); // While the MIPS spec dictates that the shift amount be masked by 31, this already happens implicitly on x86
 
     REG_64 source = alloc_reg(ee, instr.get_source(), REG_TYPE::GPR, REG_STATE::READ);
     REG_64 dest = alloc_reg(ee, instr.get_dest(), REG_TYPE::GPR, REG_STATE::WRITE);

--- a/src/core/ee/ee_jit64_gpr.cpp
+++ b/src/core/ee/ee_jit64_gpr.cpp
@@ -494,8 +494,8 @@ void EE_JIT64::divide_word(EmotionEngine& ee, IR::Instruction &instr, bool hi)
     uint8_t *label1_1 = emitter.JCC_NEAR_DEFERRED(ConditionCode::NE);
     emitter.CMP32_IMM(0xFFFFFFFF, divisor);
     uint8_t *label1_2 = emitter.JCC_NEAR_DEFERRED(ConditionCode::NE);
-    emitter.MOV64_OI((int64_t)(int32_t)0x80000000, LO);
-    emitter.MOV64_OI(0, HI);
+    emitter.MOV64_OI((int64_t)(int32_t)0x80000000, LO); // if dividing INT32_MIN / -1, set lo to INT32_MIN
+    emitter.XOR32_REG(HI, HI); // and set hi to 0
     uint8_t *end_1 = emitter.JMP_NEAR_DEFERRED();
 
     emitter.set_jump_dest(label1_1);

--- a/src/core/ee/vif.cpp
+++ b/src/core/ee/vif.cpp
@@ -103,11 +103,11 @@ void VectorInterface::update(int cycles)
             {
                 auto fifo_data = gif->read_GSFIFO();
                 //Check the GS still wants to send data
-                if (!std::get<1>(fifo_data))
+                if (!fifo_data.second)
                     return;
 
                 for (int i = 0; i < 4; i++)
-                    FIFO.push(std::get<0>(fifo_data)._u32[i]);
+                    FIFO.push(fifo_data.first._u32[i]);
             }
             else
                 break;
@@ -984,18 +984,18 @@ bool VectorInterface::feed_DMA(uint128_t quad)
     return true;
 }
 
-std::tuple<uint128_t, uint32_t>VectorInterface::readFIFO()
+std::pair<uint128_t, uint32_t>VectorInterface::readFIFO()
 {
     uint128_t quad;
     if (FIFO.empty())
-        return std::make_tuple(quad, false);
+        return std::make_pair(quad, false);
 
     for (int i = 0; i < 4; i++)
     {
         quad._u32[i] = FIFO.front();
         FIFO.pop();
     }
-    return std::make_tuple(quad, true);
+    return std::make_pair(quad, true);
 }
 
 uint32_t VectorInterface::get_stat()

--- a/src/core/ee/vif.hpp
+++ b/src/core/ee/vif.hpp
@@ -129,7 +129,7 @@ class VectorInterface
         bool transfer_word(uint32_t value);
         bool transfer_DMAtag(uint128_t tag);
         bool feed_DMA(uint128_t quad);
-        std::tuple<uint128_t, uint32_t>readFIFO();
+        std::pair<uint128_t, uint32_t>readFIFO();
 
         uint32_t get_stat();
         uint32_t get_mark();

--- a/src/core/ee/vu_jit64.cpp
+++ b/src/core/ee/vu_jit64.cpp
@@ -2097,8 +2097,7 @@ void VU_JIT64::mac_eq(VectorUnit &vu, IR::Instruction &instr)
 
     //dest = mac == source
     emitter.load_addr((uint64_t)vu.MAC_flags, REG_64::RAX);
-    emitter.MOV32_FROM_MEM(REG_64::RAX, REG_64::RAX);
-    emitter.AND32_EAX(0xFFFF);
+    emitter.MOVZX16_TO_32_FROM_MEM(REG_64::RAX, REG_64::RAX); // movzx eax, word ptr [rax]
     emitter.CMP16_REG(REG_64::RAX, source);
     emitter.SETCC_REG(ConditionCode::E, REG_64::RAX);
     emitter.AND32_EAX(0x1);

--- a/src/core/ee/vu_jit64.cpp
+++ b/src/core/ee/vu_jit64.cpp
@@ -2029,7 +2029,7 @@ void VU_JIT64::move_to_int(VectorUnit &vu, IR::Instruction &instr)
     }
 
     //Unsure if this is necessary
-    emitter.AND32_REG_IMM(0xFFFF, dest);
+    emitter.MOVZX16_TO_32(dest, dest); // shorter form for and dest, 0xFFFF (recommended by both g++ and Clang)
 }
 
 void VU_JIT64::move_from_int(VectorUnit &vu, IR::Instruction &instr)

--- a/src/core/emulator.cpp
+++ b/src/core/emulator.cpp
@@ -744,7 +744,7 @@ uint128_t Emulator::read128(uint32_t address)
         return vu1.read_mem<uint128_t>(address);
 
     if (address == 0x10005000)
-        return std::get<0>(vif1.readFIFO());
+        return vif1.readFIFO().first;
 
     printf("Unrecognized read128 at physical addr $%08X\n", address);
     return uint128_t::from_u32(0);

--- a/src/core/gif.cpp
+++ b/src/core/gif.cpp
@@ -494,7 +494,7 @@ void GraphicsInterface::send_PATH3_FIFO(uint128_t data)
     }
 }
 
-std::tuple<uint128_t, bool>GraphicsInterface::read_GSFIFO()
+std::pair<uint128_t, bool>GraphicsInterface::read_GSFIFO()
 {
     return gs->read_gs_download();
 }

--- a/src/core/gif.hpp
+++ b/src/core/gif.hpp
@@ -88,7 +88,7 @@ class GraphicsInterface
         void send_PATH2(uint32_t data[4]);
         void send_PATH3(uint128_t quad);
         void send_PATH3_FIFO(uint128_t quad);
-        std::tuple<uint128_t, bool>read_GSFIFO();
+        std::pair<uint128_t, bool>read_GSFIFO();
 
         void intermittent_check();
 

--- a/src/core/gs.cpp
+++ b/src/core/gs.cpp
@@ -405,7 +405,7 @@ void GraphicsSynthesizer::request_gs_download()
     gs_download_qwc = return_packet.payload.download_payload.quad_count;
 }
 
-std::tuple<uint128_t, bool>GraphicsSynthesizer::read_gs_download()
+std::pair<uint128_t, bool>GraphicsSynthesizer::read_gs_download()
 {
     bool have_data;
     uint128_t quad_data;
@@ -425,6 +425,6 @@ std::tuple<uint128_t, bool>GraphicsSynthesizer::read_gs_download()
         quad_data._u64[1] = 0;
         have_data = false;
     }
-    return std::make_tuple(quad_data, have_data);
+    return std::make_pair(quad_data, have_data);
 }
 

--- a/src/core/gs.hpp
+++ b/src/core/gs.hpp
@@ -71,6 +71,6 @@ class GraphicsSynthesizer
         void wake_gs_thread();
 
         void request_gs_download();
-        std::tuple<uint128_t, bool>read_gs_download();
+        std::pair<uint128_t, bool>read_gs_download();
 };
 #endif // GS_HPP

--- a/src/core/jitcommon/emitter64.cpp
+++ b/src/core/jitcommon/emitter64.cpp
@@ -1290,12 +1290,54 @@ void Emitter64::MOVZX8_TO_32(REG_64 source, REG_64 dest)
     modrm(0b11, dest, source);
 }
 
+// movzx r32, byte ptr [indir_source + offset]
+void Emitter64::MOVZX8_TO_32_FROM_MEM (REG_64 indir_source, REG_64 dest, uint32_t offset) {
+    rexw_r_rm(dest, indir_source); // Optional REX prefix
+    block->write<uint8_t>(0x0F); // 2-byte opcode
+    block->write<uint8_t>(0xB6);
+
+    if ((indir_source & 7) == 5 || offset) // ModRM 
+        modrm(0b10, dest, indir_source);
+    else
+        modrm(0, dest, indir_source);
+
+    if ((indir_source & 7) == 4) // SIB
+        block->write<uint8_t>(0x24);
+    if ((indir_source & 7) == 5 || offset)
+        block->write<uint32_t>(offset);
+}
+
 void Emitter64::MOVZX8_TO_64(REG_64 source, REG_64 dest)
 {
     rexw_r_rm(dest, source);
     block->write<uint8_t>(0x0F);
     block->write<uint8_t>(0xB6);
     modrm(0b11, dest, source);
+}
+
+void Emitter64::MOVZX16_TO_32(REG_64 source, REG_64 dest)
+{
+    rexw_r_rm(dest, source);
+    block->write<uint8_t>(0x0F);
+    block->write<uint8_t>(0xB7);
+    modrm(0b11, dest, source);
+}
+
+// movzx r32, word ptr [indir_source + offset]
+void Emitter64::MOVZX16_TO_32_FROM_MEM (REG_64 indir_source, REG_64 dest, uint32_t offset) {
+    rexw_r_rm(dest, indir_source); // Optional REX prefix
+    block->write<uint8_t>(0x0F); // 2-byte opcode
+    block->write<uint8_t>(0xB7);
+
+    if ((indir_source & 7) == 5 || offset) // ModRM 
+        modrm(0b10, dest, indir_source);
+    else
+        modrm(0, dest, indir_source);
+
+    if ((indir_source & 7) == 4) // SIB
+        block->write<uint8_t>(0x24);
+    if ((indir_source & 7) == 5 || offset)
+        block->write<uint32_t>(offset);
 }
 
 void Emitter64::MOVZX16_TO_64(REG_64 source, REG_64 dest)

--- a/src/core/jitcommon/emitter64.cpp
+++ b/src/core/jitcommon/emitter64.cpp
@@ -386,7 +386,7 @@ void Emitter64::CMP32_IMM(uint32_t imm, REG_64 op)
     else // 8-bit immediate version
     {
         block->write<uint8_t>(0x83);
-        modrm(0b11, 1, op);
+        modrm(0b11, 7, op);
         block->write<uint8_t>(imm);
     }
 }

--- a/src/core/jitcommon/emitter64.cpp
+++ b/src/core/jitcommon/emitter64.cpp
@@ -139,9 +139,20 @@ void Emitter64::ADD32_REG(REG_64 source, REG_64 dest)
 void Emitter64::ADD32_REG_IMM(uint32_t imm, REG_64 dest)
 {
     rex_rm(dest);
-    block->write<uint8_t>(0x81);
-    modrm(0b11, 0, dest);
-    block->write<uint32_t>(imm);
+
+    if (imm > 0xFF) // 32-bit immediate version
+    { 
+        block->write<uint8_t>(0x81);
+        modrm(0b11, 0, dest);
+        block->write<uint32_t>(imm);
+    }
+
+    else // 8-bit immediate version 
+    {
+        block->write<uint8_t>(0x83);
+        modrm(0b11, 0, dest);
+        block->write<uint8_t>(imm);
+    }
 }
 
 void Emitter64::ADD64_REG(REG_64 source, REG_64 dest)
@@ -215,9 +226,20 @@ void Emitter64::AND32_REG(REG_64 source, REG_64 dest)
 void Emitter64::AND32_REG_IMM(uint32_t imm, REG_64 dest)
 {
     rex_rm(dest);
-    block->write<uint8_t>(0x81);
-    modrm(0b11, 4, dest);
-    block->write<uint32_t>(imm);
+
+    if (imm > 0xFF) // 32-bit-immediate version
+    { 
+        block->write<uint8_t>(0x81);
+        modrm(0b11, 4, dest);
+        block->write<uint32_t>(imm);
+    }
+
+    else // 8-bit-immediate version
+    { 
+        block->write<uint8_t>(0x83);
+        modrm(0b11, 4, dest);
+        block->write<uint8_t>(imm);
+    }
 }
 
 void Emitter64::AND64_REG(REG_64 source, REG_64 dest)
@@ -353,9 +375,20 @@ void Emitter64::CMP16_REG(REG_64 op2, REG_64 op1)
 void Emitter64::CMP32_IMM(uint32_t imm, REG_64 op)
 {
     rex_rm(op);
-    block->write<uint8_t>(0x81);
-    modrm(0b11, 7, op);
-    block->write<uint32_t>(imm);
+
+    if (imm > 0xFF) // 32-bit immediate version
+    { 
+        block->write<uint8_t>(0x81);
+        modrm(0b11, 7, op);
+        block->write<uint32_t>(imm);
+    }
+
+    else // 8-bit immediate version
+    {
+        block->write<uint8_t>(0x83);
+        modrm(0b11, 1, op);
+        block->write<uint8_t>(imm);
+    }
 }
 
 void Emitter64::CMP32_IMM_MEM(uint32_t imm, REG_64 mem, uint32_t offset)
@@ -547,9 +580,20 @@ void Emitter64::OR32_REG(REG_64 source, REG_64 dest)
 void Emitter64::OR32_REG_IMM(uint32_t imm, REG_64 dest)
 {
     rex_rm(dest);
-    block->write<uint8_t>(0x81);
-    modrm(0b11, 1, dest);
-    block->write<uint32_t>(imm);
+
+    if (imm > 0xFF) // 32-bit immediate version
+    { 
+        block->write<uint8_t>(0x81);
+        modrm(0b11, 1, dest);
+        block->write<uint32_t>(imm);
+    }
+
+    else // 8-bit immediate version 
+    {
+        block->write<uint8_t>(0x83);
+        modrm(0b11, 1, dest);
+        block->write<uint8_t>(imm);
+    }
 }
 
 void Emitter64::OR32_EAX(uint32_t imm)

--- a/src/core/jitcommon/emitter64.hpp
+++ b/src/core/jitcommon/emitter64.hpp
@@ -202,7 +202,10 @@ class Emitter64
         void MOVSX16_TO_64(REG_64 source, REG_64 dest);
         void MOVSX32_TO_64(REG_64 source, REG_64 dest);
         void MOVZX8_TO_32(REG_64 source, REG_64 dest);
+        void MOVZX8_TO_32_FROM_MEM (REG_64 indir_source, REG_64 dest, uint32_t offset = 0); // movzx source, byte ptr [indir_rest + offset]
         void MOVZX8_TO_64(REG_64 source, REG_64 dest);
+        void MOVZX16_TO_32(REG_64 source, REG_64 dest);
+        void MOVZX16_TO_32_FROM_MEM (REG_64 indir_source, REG_64 dest, uint32_t offset = 0); // movzx source, word ptr [indir_rest + offset]
         void MOVZX16_TO_64(REG_64 source, REG_64 dest);
 
         void MOVD_FROM_MEM(REG_64 indir_source, REG_64 xmm_dest);


### PR DESCRIPTION
- Some ands -> movzx (smaller, no immediate, preferred by compilers. Also a movzx from memory can replace a mov from memory + and in some cases)
- cmp r64, 0 -> test r64, r64 (less space wasted on immediate
- mov r64, 0 -> xor r64, r64 (provided we don't want to preserve flags)
- Added 3 movzx addressing modes to emitter
- Changed std::tuple with 2 elements to std::pair, because the latter should be easier to optimize for compilers and less dubious (as an std::pair devolves into a very simple struct)
- Removed unnecessary shift masking
- Optimized certain instruction in the emitter such as `add r32, imm` to use the smallest possible immediate