### PR TITLE
Rework savestate code

### DIFF
--- a/DobieStation/application/application.pro
+++ b/DobieStation/application/application.pro
@@ -180,6 +180,7 @@ HEADERS += \
     ../../src/core/ee/vu_interpreter.hpp \
     ../../src/core/ee/vu_disasm.hpp \
     ../../src/core/gsmem.hpp \
+    ../../src/core/serialize.hpp \
     ../../src/core/iop/memcard.hpp \
     ../../src/qt/settings.hpp \
     ../../src/core/jitcommon/jitcache.hpp \

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -108,6 +108,7 @@ set(HEADERS
     gsthread.hpp
     int128.hpp
     scheduler.hpp
+    serialize.hpp
     sif.hpp
     audio/utils.hpp
     ee/bios_hle.hpp

--- a/src/core/Core.vcxproj
+++ b/src/core/Core.vcxproj
@@ -212,6 +212,7 @@
     <ClInclude Include="ee\ipu\mac_p_pic.hpp" />
     <ClInclude Include="iop\memcard.hpp" />
     <ClInclude Include="ee\ipu\motioncode.hpp" />
+    <ClInclude Include="serialize.hpp" />
     <ClInclude Include="sif.hpp" />
     <ClInclude Include="iop\sio2.hpp" />
     <ClInclude Include="iop\spu\spu.hpp" />

--- a/src/core/Core.vcxproj.filters
+++ b/src/core/Core.vcxproj.filters
@@ -398,6 +398,9 @@
     <ClInclude Include="ee\ipu\motioncode.hpp">
       <Filter>Headers</Filter>
     </ClInclude>
+    <ClInclude Include="serialize.hpp">
+      <Filter>Headers</Filter>
+    </ClInclude>
     <ClInclude Include="sif.hpp">
       <Filter>Headers</Filter>
     </ClInclude>

--- a/src/core/ee/cop0.hpp
+++ b/src/core/ee/cop0.hpp
@@ -2,6 +2,7 @@
 #define COP0_HPP
 #include <cstdint>
 #include <fstream>
+#include "core/serialize.hpp"
 
 
 class EE_JIT64;
@@ -129,8 +130,7 @@ class Cop0
         void set_tlb_modified(size_t page);
         bool get_tlb_modified(size_t page) const;
 
-        void load_state(std::ifstream &state);
-        void save_state(std::ofstream& state);
+        void do_state(StateSerializer &state);
 
         //Friends needed for JIT convenience
         friend class EE_JIT64;

--- a/src/core/ee/cop0.hpp
+++ b/src/core/ee/cop0.hpp
@@ -2,7 +2,7 @@
 #define COP0_HPP
 #include <cstdint>
 #include <fstream>
-#include "core/serialize.hpp"
+#include "../serialize.hpp"
 
 
 class EE_JIT64;

--- a/src/core/ee/cop1.hpp
+++ b/src/core/ee/cop1.hpp
@@ -2,6 +2,7 @@
 #define COP1_HPP
 #include <cstdint>
 #include <fstream>
+#include "core/serialize.hpp"
 
 class EE_JIT64;
 class EmotionEngine;
@@ -77,8 +78,7 @@ class Cop1
         void c_eq_s(int reg1, int reg2);
         void c_le_s(int reg1, int reg2);
 
-        void load_state(std::ifstream& state);
-        void save_state(std::ofstream& state);
+        void do_state(StateSerializer &state);
 
         //Friends needed for JIT convenience
         friend class EE_JIT64;

--- a/src/core/ee/cop1.hpp
+++ b/src/core/ee/cop1.hpp
@@ -2,7 +2,7 @@
 #define COP1_HPP
 #include <cstdint>
 #include <fstream>
-#include "core/serialize.hpp"
+#include "../serialize.hpp"
 
 class EE_JIT64;
 class EmotionEngine;

--- a/src/core/ee/dmac.hpp
+++ b/src/core/ee/dmac.hpp
@@ -5,6 +5,7 @@
 #include <list>
 
 #include "../int128.hpp"
+#include "core/serialize.hpp"
 
 enum DMAC_CHANNELS
 {
@@ -157,8 +158,7 @@ class DMAC
         void set_DMA_request(int index);
         void clear_DMA_request(int index);
 
-        void load_state(std::ifstream& state);
-        void save_state(std::ofstream& state);
+        void do_state(StateSerializer& state);
 };
 
 #endif // DMAC_HPP

--- a/src/core/ee/dmac.hpp
+++ b/src/core/ee/dmac.hpp
@@ -5,7 +5,7 @@
 #include <list>
 
 #include "../int128.hpp"
-#include "core/serialize.hpp"
+#include "../serialize.hpp"
 
 enum DMAC_CHANNELS
 {

--- a/src/core/ee/emotion.hpp
+++ b/src/core/ee/emotion.hpp
@@ -8,6 +8,7 @@
 #include "cop1.hpp"
 
 #include "../int128.hpp"
+#include "core/serialize.hpp"
 
 class Emulator;
 class VectorUnit;
@@ -214,8 +215,7 @@ class EmotionEngine
         void qmtc2(int source, int cop_reg);
         void cop2_updatevu0();
 
-        void load_state(std::ifstream& state);
-        void save_state(std::ofstream& state);
+        void do_state(StateSerializer &state);
 
         //Friends needed for JIT convenience
         friend class EE_JIT64;

--- a/src/core/ee/emotion.hpp
+++ b/src/core/ee/emotion.hpp
@@ -8,7 +8,7 @@
 #include "cop1.hpp"
 
 #include "../int128.hpp"
-#include "core/serialize.hpp"
+#include "../serialize.hpp"
 
 class Emulator;
 class VectorUnit;

--- a/src/core/ee/intc.hpp
+++ b/src/core/ee/intc.hpp
@@ -2,6 +2,7 @@
 #define INTC_HPP
 #include <cstdint>
 #include <fstream>
+#include "core/serialize.hpp"
 
 class EmotionEngine;
 class Scheduler;
@@ -50,8 +51,7 @@ class INTC
         void assert_IRQ(int id);
         void deassert_IRQ(int id);
 
-        void load_state(std::ifstream& state);
-        void save_state(std::ofstream& state);
+        void do_state(StateSerializer& state);
 };
 
 #endif // INTC_HPP

--- a/src/core/ee/intc.hpp
+++ b/src/core/ee/intc.hpp
@@ -2,7 +2,7 @@
 #define INTC_HPP
 #include <cstdint>
 #include <fstream>
-#include "core/serialize.hpp"
+#include "../serialize.hpp"
 
 class EmotionEngine;
 class Scheduler;

--- a/src/core/ee/timers.hpp
+++ b/src/core/ee/timers.hpp
@@ -2,6 +2,7 @@
 #define TIMERS_HPP
 #include <cstdint>
 #include <fstream>
+#include "core/serialize.hpp"
 
 struct TimerControl
 {
@@ -61,8 +62,7 @@ class EmotionTiming
         uint32_t read32(uint32_t addr);
         void write32(uint32_t addr, uint32_t value);
 
-        void load_state(std::ifstream& state);
-        void save_state(std::ofstream& state);
+        void do_state(StateSerializer& state);
 };
 
 #endif // TIMERS_HPP

--- a/src/core/ee/timers.hpp
+++ b/src/core/ee/timers.hpp
@@ -2,7 +2,7 @@
 #define TIMERS_HPP
 #include <cstdint>
 #include <fstream>
-#include "core/serialize.hpp"
+#include "../serialize.hpp"
 
 struct TimerControl
 {

--- a/src/core/ee/vif.hpp
+++ b/src/core/ee/vif.hpp
@@ -8,6 +8,7 @@
 #include "intc.hpp"
 #include "vu.hpp"
 
+#include "core/serialize.hpp"
 #include "../int128.hpp"
 
 class GraphicsInterface;
@@ -144,8 +145,7 @@ class VectorInterface
         void set_err(uint32_t value);
         void set_fbrst(uint32_t value);
 
-        void load_state(std::ifstream& state);
-        void save_state(std::ofstream& state);
+        void do_state(StateSerializer& state);
 };
 
 inline int VectorInterface::get_id()

--- a/src/core/ee/vif.hpp
+++ b/src/core/ee/vif.hpp
@@ -8,7 +8,7 @@
 #include "intc.hpp"
 #include "vu.hpp"
 
-#include "core/serialize.hpp"
+#include "../serialize.hpp"
 #include "../int128.hpp"
 
 class GraphicsInterface;

--- a/src/core/ee/vu.hpp
+++ b/src/core/ee/vu.hpp
@@ -6,6 +6,7 @@
 #include <unordered_set>
 #include "emotion.hpp"
 #include "../int128.hpp"
+#include "core/serialize.hpp"
 
 union alignas(16) VU_R
 {
@@ -385,8 +386,7 @@ class VectorUnit
         void xitop(uint32_t instr);
         void xtop(uint32_t instr);
 
-        void load_state(std::ifstream& state);
-        void save_state(std::ofstream& state);
+        void do_state(StateSerializer& state);
 
         //Friends needed for JIT convenience
         friend class VU_JIT64;

--- a/src/core/ee/vu.hpp
+++ b/src/core/ee/vu.hpp
@@ -6,7 +6,7 @@
 #include <unordered_set>
 #include "emotion.hpp"
 #include "../int128.hpp"
-#include "core/serialize.hpp"
+#include "../serialize.hpp"
 
 union alignas(16) VU_R
 {

--- a/src/core/emulator.hpp
+++ b/src/core/emulator.hpp
@@ -27,6 +27,7 @@
 #include "gif.hpp"
 #include "sif.hpp"
 #include "scheduler.hpp"
+#include "serialize.hpp"
 
 enum SKIP_HACK
 {
@@ -144,6 +145,7 @@ class Emulator
         void request_gsdump_single_frame();
         void load_state(const char* file_name);
         void save_state(const char* file_name);
+        void do_state(StateSerializer &state);
 
         bool interlock_cop2_check(bool isCOP2);
         void clear_cop2_interlock();

--- a/src/core/gif.hpp
+++ b/src/core/gif.hpp
@@ -6,6 +6,7 @@
 
 #include "gs.hpp"
 #include "int128.hpp"
+#include "core/serialize.hpp"
 
 class DMAC;
 
@@ -92,8 +93,7 @@ class GraphicsInterface
 
         void intermittent_check();
 
-        void load_state(std::ifstream& state);
-        void save_state(std::ofstream& state);
+        void do_state(StateSerializer& state);
 };
 
 inline int GraphicsInterface::get_active_path()

--- a/src/core/gif.hpp
+++ b/src/core/gif.hpp
@@ -6,7 +6,7 @@
 
 #include "gs.hpp"
 #include "int128.hpp"
-#include "core/serialize.hpp"
+#include "serialize.hpp"
 
 class DMAC;
 

--- a/src/core/gs.cpp
+++ b/src/core/gs.cpp
@@ -339,29 +339,16 @@ void GraphicsSynthesizer::set_XYZF(uint32_t x, uint32_t y, uint32_t z, uint8_t f
     gs_thread.send_message({ GSCommand::set_xyzf_t, payload });
 }
 
-void GraphicsSynthesizer::load_state(std::ifstream &state)
+void GraphicsSynthesizer::do_state(StateSerializer& state)
 {
     GSMessagePayload payload;
-    payload.load_state_payload = {&state};
-    gs_thread.send_message({ GSCommand::load_state_t, payload });
+    payload.do_state_payload = {&state};
+    gs_thread.send_message({ GSCommand::do_state_t, payload });
     gs_thread.wake_thread();
     GSReturnMessage data;
-    gs_thread.wait_for_return(GSReturn::load_state_done_t, data);
-    
-    state.read((char*)&reg, sizeof(reg));
-}
+    gs_thread.wait_for_return(GSReturn::do_state_done_t, data);
 
-void GraphicsSynthesizer::save_state(std::ofstream &state)
-{
-    GSMessagePayload payload;
-    payload.save_state_payload = {&state};
-
-    gs_thread.send_message({ GSCommand::save_state_t, payload });
-    gs_thread.wake_thread();
-    GSReturnMessage data;
-    gs_thread.wait_for_return(GSReturn::save_state_done_t, data);
-    
-    state.write((char*)&reg, sizeof(reg));
+    state.Do(&reg);
 }
 
 void GraphicsSynthesizer::send_dump_request()

--- a/src/core/gs.hpp
+++ b/src/core/gs.hpp
@@ -5,6 +5,7 @@
 #include <mutex>
 #include "gsthread.hpp"
 #include "gsregisters.hpp"
+#include "core/serialize.hpp"
 
 class INTC;
 
@@ -63,8 +64,7 @@ class GraphicsSynthesizer
         void set_XYZ(uint32_t x, uint32_t y, uint32_t z, bool drawing_kick);
         void set_XYZF(uint32_t x, uint32_t y, uint32_t z, uint8_t fog, bool drawing_kick);
 
-        void load_state(std::ifstream& state);
-        void save_state(std::ofstream& state);
+        void do_state(StateSerializer& state);
         void send_dump_request();
 
         void send_message(GSMessage message);

--- a/src/core/gs.hpp
+++ b/src/core/gs.hpp
@@ -5,7 +5,7 @@
 #include <mutex>
 #include "gsthread.hpp"
 #include "gsregisters.hpp"
-#include "core/serialize.hpp"
+#include "serialize.hpp"
 
 class INTC;
 

--- a/src/core/gsthread.cpp
+++ b/src/core/gsthread.cpp
@@ -231,7 +231,8 @@ void GraphicsSynthesizerThread::event_loop()
     printf("[GS_t] Starting GS Thread\n");
 
     bool gsdump_recording = false;
-    ofstream gsdump_file;
+    fstream gsdump_file;
+    auto gsdump = StateSerializer(gsdump_file, StateSerializer::Mode::Write);
 
     try
     {
@@ -242,7 +243,7 @@ void GraphicsSynthesizerThread::event_loop()
             if (message_queue->pop(data))
             {
                 if (gsdump_recording)
-                    gsdump_file.write((char*)&data, sizeof(data));
+                    gsdump.Do(&data);
 
                 switch (data.type)
                 {
@@ -369,7 +370,6 @@ void GraphicsSynthesizerThread::event_loop()
                         notifier.notify_one();
                         break;
                     }
-                   /*
                     case gsdump_t:
                     {
                         printf("gs dump! ");
@@ -380,8 +380,8 @@ void GraphicsSynthesizerThread::event_loop()
                             if (!gsdump_file.is_open())
                                 Errors::die("gs dump file failed to open");
                             gsdump_recording = true;
-                            save_state(&gsdump_file);
-                            gsdump_file.write((char*)&reg, sizeof(reg));
+                            do_state(&gsdump);
+                            gsdump.Do(&reg);
                         }
                         else
                         {
@@ -391,7 +391,6 @@ void GraphicsSynthesizerThread::event_loop()
                         }
                         break;
                     }
-                    */
                     case request_local_host_tx:
                     {
                         auto p = data.payload.download_payload;

--- a/src/core/gsthread.hpp
+++ b/src/core/gsthread.hpp
@@ -10,6 +10,7 @@
 #include "gsregisters.hpp"
 #include "circularFIFO.hpp"
 #include "int128.hpp"
+#include "core/serialize.hpp"
 
 #include "jitcommon/emitter64.hpp"
 
@@ -35,7 +36,7 @@ enum GSCommand:uint8_t
     write64_t, write64_privileged_t, write32_privileged_t,
     set_rgba_t, set_st_t, set_uv_t, set_xyz_t, set_xyzf_t, set_crt_t,
     render_crt_t, assert_finish_t, assert_hblank_t, assert_vsync_t, swap_field_t, memdump_t, die_t,
-    save_state_t, load_state_t, gsdump_t, request_local_host_tx,
+    do_state_t, gsdump_t, request_local_host_tx,
 };
 
 union GSMessagePayload 
@@ -96,12 +97,8 @@ union GSMessagePayload
     } download_payload;
     struct
     {
-        std::ofstream* state;
-    } save_state_payload;
-    struct
-    {
-        std::ifstream* state;
-    } load_state_payload;
+        StateSerializer* state;
+    } do_state_payload;
     struct 
     {
         uint8_t BLANK; 
@@ -119,8 +116,7 @@ enum GSReturn :uint8_t
 {
     render_complete_t,
     death_error_t,
-    save_state_done_t,
-    load_state_done_t,
+    do_state_done_t,
     gsdump_render_partial_done_t,
     local_host_transfer,
 };
@@ -531,8 +527,7 @@ class GraphicsSynthesizerThread
         void set_XYZ(uint32_t x, uint32_t y, uint32_t z, bool drawing_kick);
         void set_XYZF(uint32_t x, uint32_t y, uint32_t z, uint8_t fog, bool drawing_kick);
 
-        void load_state(std::ifstream* state);
-        void save_state(std::ofstream* state);
+        void do_state(StateSerializer* state);
     public:
         GraphicsSynthesizerThread();
         ~GraphicsSynthesizerThread();

--- a/src/core/gsthread.hpp
+++ b/src/core/gsthread.hpp
@@ -10,7 +10,7 @@
 #include "gsregisters.hpp"
 #include "circularFIFO.hpp"
 #include "int128.hpp"
-#include "core/serialize.hpp"
+#include "serialize.hpp"
 
 #include "jitcommon/emitter64.hpp"
 

--- a/src/core/iop/cdvd/cdvd.hpp
+++ b/src/core/iop/cdvd/cdvd.hpp
@@ -5,7 +5,7 @@
 #include <memory>
 #include <algorithm>
 #include <string.h>
-#include "core/serialize.hpp"
+#include "../../serialize.hpp"
 #include "cdvd_container.hpp"
 
 class IOP_INTC;

--- a/src/core/iop/cdvd/cdvd.hpp
+++ b/src/core/iop/cdvd/cdvd.hpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <algorithm>
 #include <string.h>
+#include "core/serialize.hpp"
 #include "cdvd_container.hpp"
 
 class IOP_INTC;
@@ -170,8 +171,7 @@ class CDVD_Drive
         void write_ISTAT(uint8_t value);
         void write_mecha_decode(uint8_t value);
 
-        void load_state(std::ifstream& state);
-        void save_state(std::ofstream& state);
+        void do_state(StateSerializer& state);
 };
 
 #endif // CDVD_HPP

--- a/src/core/iop/gamepad.hpp
+++ b/src/core/iop/gamepad.hpp
@@ -2,6 +2,7 @@
 #define GAMEPAD_HPP
 #include <cstdint>
 #include <fstream>
+#include "core/serialize.hpp"
 
 enum class PAD_BUTTON
 {
@@ -83,8 +84,7 @@ class Gamepad
         uint8_t start_transfer(uint8_t value);
         uint8_t write_SIO(uint8_t value);
 
-        void load_state(std::ifstream& state);
-        void save_state(std::ofstream& state);
+        void do_state(StateSerializer &state);
 };
 
 #endif // GAMEPAD_HPP

--- a/src/core/iop/gamepad.hpp
+++ b/src/core/iop/gamepad.hpp
@@ -2,7 +2,7 @@
 #define GAMEPAD_HPP
 #include <cstdint>
 #include <fstream>
-#include "core/serialize.hpp"
+#include "../serialize.hpp"
 
 enum class PAD_BUTTON
 {

--- a/src/core/iop/iop.hpp
+++ b/src/core/iop/iop.hpp
@@ -5,7 +5,7 @@
 #include <cstdio>
 #include <fstream>
 #include "iop_cop0.hpp"
-#include "core/serialize.hpp"
+#include "../serialize.hpp"
 
 class Emulator;
 

--- a/src/core/iop/iop.hpp
+++ b/src/core/iop/iop.hpp
@@ -5,6 +5,7 @@
 #include <cstdio>
 #include <fstream>
 #include "iop_cop0.hpp"
+#include "core/serialize.hpp"
 
 class Emulator;
 
@@ -79,8 +80,7 @@ class IOP
         void write16(uint32_t addr, uint16_t value);
         void write32(uint32_t addr, uint32_t value);
 
-        void load_state(std::ifstream& state);
-        void save_state(std::ofstream& state);
+        void do_state(StateSerializer& state);
 };
 
 inline void IOP::halt()

--- a/src/core/iop/iop_dma.hpp
+++ b/src/core/iop/iop_dma.hpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <fstream>
 #include <list>
+#include "core/serialize.hpp"
 
 class IOP_DMA;
 
@@ -133,8 +134,7 @@ class IOP_DMA
         void set_chan_control(int index, uint32_t value);
         void set_chan_tag_addr(int index, uint32_t value);
 
-        void load_state(std::ifstream& state);
-        void save_state(std::ofstream& state);
+        void do_state(StateSerializer& state);
 };
 
 #endif // IOP_DMA_HPP

--- a/src/core/iop/iop_dma.hpp
+++ b/src/core/iop/iop_dma.hpp
@@ -3,7 +3,7 @@
 #include <cstdint>
 #include <fstream>
 #include <list>
-#include "core/serialize.hpp"
+#include "../serialize.hpp"
 
 class IOP_DMA;
 

--- a/src/core/iop/iop_intc.hpp
+++ b/src/core/iop/iop_intc.hpp
@@ -2,6 +2,7 @@
 #define IOP_INTC_HPP
 #include <cstdint>
 #include <fstream>
+#include "core/serialize.hpp"
 
 class IOP;
 
@@ -27,8 +28,7 @@ class IOP_INTC
         void write_istat(uint32_t value);
         void write_ictrl(uint32_t value);
 
-        void load_state(std::ifstream& state);
-        void save_state(std::ofstream& state);
+        void do_state(StateSerializer& state);
 };
 
 #endif // IOP_INTC_HPP

--- a/src/core/iop/iop_intc.hpp
+++ b/src/core/iop/iop_intc.hpp
@@ -2,7 +2,7 @@
 #define IOP_INTC_HPP
 #include <cstdint>
 #include <fstream>
-#include "core/serialize.hpp"
+#include "../serialize.hpp"
 
 class IOP;
 

--- a/src/core/iop/iop_timers.hpp
+++ b/src/core/iop/iop_timers.hpp
@@ -2,6 +2,7 @@
 #define IOP_TIMERS_HPP
 #include <cstdint>
 #include <fstream>
+#include "core/serialize.hpp"
 
 struct IOP_Timer_Control
 {
@@ -55,8 +56,7 @@ class IOPTiming
         void write_control(int index, uint16_t value);
         void write_target(int index, uint32_t value);
 
-        void load_state(std::ifstream& state);
-        void save_state(std::ofstream& state);
+        void do_state(StateSerializer& state);
 };
 
 #endif // IOP_TIMERS_HPP

--- a/src/core/iop/iop_timers.hpp
+++ b/src/core/iop/iop_timers.hpp
@@ -2,7 +2,7 @@
 #define IOP_TIMERS_HPP
 #include <cstdint>
 #include <fstream>
-#include "core/serialize.hpp"
+#include "../serialize.hpp"
 
 struct IOP_Timer_Control
 {

--- a/src/core/iop/spu/spu.hpp
+++ b/src/core/iop/spu/spu.hpp
@@ -2,6 +2,7 @@
 #define SPU_HPP
 #include <cstdint>
 #include <fstream>
+#include "core/serialize.hpp"
 #include "spu_envelope.hpp"
 #include "../../audio/utils.hpp"
 #include "spu_adpcm.hpp"
@@ -292,8 +293,7 @@ class SPU
 
         void gaussianConstructTable();
 
-        void load_state(std::ifstream& state);
-        void save_state(std::ofstream& state);
+        void do_state(StateSerializer& state);
 
 };
 

--- a/src/core/iop/spu/spu.hpp
+++ b/src/core/iop/spu/spu.hpp
@@ -2,7 +2,7 @@
 #define SPU_HPP
 #include <cstdint>
 #include <fstream>
-#include "core/serialize.hpp"
+#include "../../serialize.hpp"
 #include "spu_envelope.hpp"
 #include "../../audio/utils.hpp"
 #include "spu_adpcm.hpp"

--- a/src/core/scheduler.hpp
+++ b/src/core/scheduler.hpp
@@ -4,6 +4,7 @@
 #include <functional>
 #include <list>
 #include <vector>
+#include "core/serialize.hpp"
 
 struct CycleCount
 {
@@ -93,8 +94,7 @@ class Scheduler
         void update_cycle_counts();
         void process_events();
 
-        void load_state(std::ifstream& state);
-        void save_state(std::ofstream& state);
+        void do_state(StateSerializer& state);
 };
 
 inline int64_t Scheduler::get_ee_cycles()

--- a/src/core/scheduler.hpp
+++ b/src/core/scheduler.hpp
@@ -4,7 +4,7 @@
 #include <functional>
 #include <list>
 #include <vector>
-#include "core/serialize.hpp"
+#include "serialize.hpp"
 
 struct CycleCount
 {

--- a/src/core/serialize.cpp
+++ b/src/core/serialize.cpp
@@ -1,14 +1,13 @@
-#include <fstream>
-#include <cstring>
+#include "serialize.hpp"
 #include "emulator.hpp"
+#include <cstring>
+#include <fstream>
 
-#define VER_MAJOR 0
-#define VER_MINOR 0
-#define VER_REV 50
+static constexpr uint32_t STATE_VERSION = 51;
 
 using namespace std;
 
-bool Emulator::request_load_state(const char *file_name)
+bool Emulator::request_load_state(const char* file_name)
 {
     ifstream state(file_name, ios::binary);
     if (!state.is_open())
@@ -19,7 +18,7 @@ bool Emulator::request_load_state(const char *file_name)
     return true;
 }
 
-bool Emulator::request_save_state(const char *file_name)
+bool Emulator::request_save_state(const char* file_name)
 {
     ofstream state(file_name, ios::binary);
     if (!state.is_open())
@@ -30,33 +29,29 @@ bool Emulator::request_save_state(const char *file_name)
     return true;
 }
 
-void Emulator::load_state(const char *file_name)
+void Emulator::load_state(const char* file_name)
 {
     load_requested = false;
     printf("[Emulator] Loading state...\n");
-    ifstream state(file_name, ios::binary);
+    fstream state(file_name, ios::binary | fstream::in);
     if (!state.is_open())
     {
         Errors::non_fatal("Failed to load save state");
         return;
     }
 
-    //Perform sanity checks
-    char dobie_buffer[5];
-    state.read(dobie_buffer, sizeof(dobie_buffer));
-    if (strncmp(dobie_buffer, "DOBIE", 5))
+    StateSerializer ss(state, StateSerializer::Mode::Read);
+    if (ss.DoMarker("DOBIE") == false)
     {
         state.close();
         Errors::non_fatal("Save state invalid");
         return;
     }
 
-    uint32_t major, minor, rev;
-    state.read((char*)&major, sizeof(major));
-    state.read((char*)&minor, sizeof(minor));
-    state.read((char*)&rev, sizeof(rev));
+    uint32_t rev = 0;
+    ss.Do(&rev);
 
-    if (major != VER_MAJOR || minor != VER_MINOR || rev != VER_REV)
+    if (rev != STATE_VERSION)
     {
         state.close();
         Errors::non_fatal("Save state doesn't match version");
@@ -65,1010 +60,526 @@ void Emulator::load_state(const char *file_name)
 
     reset();
 
-    //Emulator info
-    state.read((char*)&VBLANK_sent, sizeof(VBLANK_sent));
-    state.read((char*)&frames, sizeof(frames));
-
-    //RAM
-    state.read((char*)RDRAM, 1024 * 1024 * 32);
-    state.read((char*)IOP_RAM, 1024 * 1024 * 2);
-    state.read((char*)SPU_RAM, 1024 * 1024 * 2);
-    state.read((char*)scratchpad, 1024 * 16);
-    state.read((char*)iop_scratchpad, 1024);
-    state.read((char*)&iop_scratchpad_start, sizeof(iop_scratchpad_start));
-
-    //CPUs
-    cpu.load_state(state);
-    cp0.load_state(state);
-    fpu.load_state(state);
-    iop.load_state(state);
-    vu0.load_state(state);
-    vu1.load_state(state);
-
-    //Interrupt registers
-    intc.load_state(state);
-    iop_intc.load_state(state);
-
-    //Timers
-    timers.load_state(state);
-    iop_timers.load_state(state);
-
-    //DMA
-    dmac.load_state(state);
-    iop_dma.load_state(state);
-
-    //"Interfaces"
-    gif.load_state(state);
-    sif.load_state(state);
-    vif0.load_state(state);
-    vif1.load_state(state);
-
-    //CDVD
-    cdvd.load_state(state);
-
-    //GS
-    //Important note - this serialization function is located in gs.cpp as it contains a lot of thread-specific details
-    gs.load_state(state);
-
-    scheduler.load_state(state);
-    pad.load_state(state);
-    spu.load_state(state);
-    spu2.load_state(state);
+    do_state(ss);
 
     state.close();
     printf("[Emulator] Success!\n");
 }
 
-void Emulator::save_state(const char *file_name)
+void Emulator::save_state(const char* file_name)
 {
     save_requested = false;
+
     printf("[Emulator] Saving state...\n");
-    ofstream state(file_name, ios::binary);
+    fstream state(file_name, ios::binary | fstream::out | fstream::trunc);
     if (!state.is_open())
     {
         Errors::non_fatal("Failed to save state");
         return;
     }
 
-    uint32_t major = VER_MAJOR;
-    uint32_t minor = VER_MINOR;
-    uint32_t rev = VER_REV;
+    StateSerializer ss(state, StateSerializer::Mode::Write);
+    ss.DoMarker("DOBIE");
+    ss.Do(&STATE_VERSION);
 
-    //Sanity check and version
-    state << "DOBIE";
-    state.write((char*)&major, sizeof(uint32_t));
-    state.write((char*)&minor, sizeof(uint32_t));
-    state.write((char*)&rev, sizeof(uint32_t));
-
-    //Emulator info
-    state.write((char*)&VBLANK_sent, sizeof(VBLANK_sent));
-    state.write((char*)&frames, sizeof(frames));
-
-    //RAM
-    state.write((char*)RDRAM, 1024 * 1024 * 32);
-    state.write((char*)IOP_RAM, 1024 * 1024 * 2);
-    state.write((char*)SPU_RAM, 1024 * 1024 * 2);
-    state.write((char*)scratchpad, 1024 * 16);
-    state.write((char*)iop_scratchpad, 1024);
-    state.write((char*)&iop_scratchpad_start, sizeof(iop_scratchpad_start));
-
-    //CPUs
-    cpu.save_state(state);
-    cp0.save_state(state);
-    fpu.save_state(state);
-    iop.save_state(state);
-    vu0.save_state(state);
-    vu1.save_state(state);
-
-    //Interrupt registers
-    intc.save_state(state);
-    iop_intc.save_state(state);
-
-    //Timers
-    timers.save_state(state);
-    iop_timers.save_state(state);
-
-    //DMA
-    dmac.save_state(state);
-    iop_dma.save_state(state);
-
-    //"Interfaces"
-    gif.save_state(state);
-    sif.save_state(state);
-    vif0.save_state(state);
-    vif1.save_state(state);
-
-    //CDVD
-    cdvd.save_state(state);
-
-    //GS
-    //Important note - this serialization function is located in gs.cpp as it contains a lot of thread-specific details
-    gs.save_state(state);
-
-    scheduler.save_state(state);
-    pad.save_state(state);
-    spu.save_state(state);
-    spu2.save_state(state);
+    do_state(ss);
 
     state.close();
     printf("Success!\n");
 }
 
-void EmotionEngine::load_state(ifstream &state)
+void Emulator::do_state(StateSerializer& state)
 {
-    state.read((char*)&cycle_count, sizeof(cycle_count));
-    state.read((char*)&cycles_to_run, sizeof(cycles_to_run));
-    state.read((char*)&icache, sizeof(icache));
-    state.read((char*)&gpr, sizeof(gpr));
-    state.read((char*)&LO, sizeof(uint64_t));
-    state.read((char*)&HI, sizeof(uint64_t));
-    state.read((char*)&LO.hi, sizeof(uint64_t));
-    state.read((char*)&HI.hi, sizeof(uint64_t));
-    state.read((char*)&PC, sizeof(uint32_t));
-    state.read((char*)&new_PC, sizeof(uint32_t));
-    state.read((char*)&SA, sizeof(uint64_t));
+    //Emulator info
+    state.Do(&VBLANK_sent);
+    state.Do(&frames);
 
-    //state.read((char*)&IRQ_raised, sizeof(IRQ_raised));
-    state.read((char*)&wait_for_IRQ, sizeof(wait_for_IRQ));
-    state.read((char*)&branch_on, sizeof(branch_on));
-    state.read((char*)&delay_slot, sizeof(delay_slot));
+    //RAM
+    state.DoBytes(RDRAM, 1024 * 1024 * 32);
+    state.DoBytes(IOP_RAM, 1024 * 1024 * 2);
+    state.DoBytes(SPU_RAM, 1024 * 1024 * 2);
+    state.DoBytes(scratchpad, 1024 * 16);
+    state.DoBytes(iop_scratchpad, 1024);
+    state.Do(&iop_scratchpad_start);
 
-    state.read((char*)&deci2size, sizeof(deci2size));
-    state.read((char*)&deci2handlers, sizeof(Deci2Handler) * deci2size);
+    //CPUs
+    cpu.do_state(state);
+    cp0.do_state(state);
+    fpu.do_state(state);
+    iop.do_state(state);
+    vu0.do_state(state);
+    vu1.do_state(state);
+
+    //Interrupt registers
+    intc.do_state(state);
+    iop_intc.do_state(state);
+
+    ////Timers
+    timers.do_state(state);
+    iop_timers.do_state(state);
+
+    ////DMA
+    dmac.do_state(state);
+    iop_dma.do_state(state);
+
+    ////"Interfaces"
+    gif.do_state(state);
+    sif.do_state(state);
+    vif0.do_state(state);
+    vif1.do_state(state);
+
+    ////CDVD
+    cdvd.do_state(state);
+
+    ////GS
+    ////Important note - this serialization function is located in gs.cpp as it contains a lot of thread-specific details
+    gs.do_state(state);
+
+    scheduler.do_state(state);
+    pad.do_state(state);
+    spu.do_state(state);
+    spu2.do_state(state);
 }
 
-void EmotionEngine::save_state(ofstream &state)
+void EmotionEngine::do_state(StateSerializer& state)
 {
-    state.write((char*)&cycle_count, sizeof(cycle_count));
-    state.write((char*)&cycles_to_run, sizeof(cycles_to_run));
-    state.write((char*)&icache, sizeof(icache));
-    state.write((char*)&gpr, sizeof(gpr));
-    state.write((char*)&LO, sizeof(uint64_t));
-    state.write((char*)&HI, sizeof(uint64_t));
-    state.write((char*)&LO.lo, sizeof(uint64_t));
-    state.write((char*)&HI.hi, sizeof(uint64_t));
-    state.write((char*)&PC, sizeof(uint32_t));
-    state.write((char*)&new_PC, sizeof(uint32_t));
-    state.write((char*)&SA, sizeof(uint64_t));
+    state.Do(&cycle_count);
+    state.Do(&cycles_to_run);
+    state.DoArray(icache, 128);
+    state.DoArray(gpr, 512);
+    state.Do(&LO);
+    state.Do(&HI);
+    state.Do(&LO.hi);
+    state.Do(&HI.hi);
+    state.Do(&PC);
+    state.Do(&new_PC);
+    state.Do(&SA);
 
-    //state.write((char*)&IRQ_raised, sizeof(IRQ_raised));
-    state.write((char*)&wait_for_IRQ, sizeof(wait_for_IRQ));
-    state.write((char*)&branch_on, sizeof(branch_on));
-    state.write((char*)&delay_slot, sizeof(delay_slot));
+    state.Do(&wait_for_IRQ);
+    state.Do(&branch_on);
+    state.Do(&delay_slot);
 
-    state.write((char*)&deci2size, sizeof(deci2size));
-    state.write((char*)&deci2handlers, sizeof(Deci2Handler) * deci2size);
+    state.Do(&deci2size);
+    //state.DoBytes(&deci2handlers, sizeof(Deci2Handler) * deci2size);
+    state.DoArray(deci2handlers, 128);
 }
 
-void Cop0::load_state(ifstream &state)
+void Cop0::do_state(StateSerializer& state)
 {
-    state.read((char*)&gpr, sizeof(gpr));
-    state.read((char*)&status, sizeof(status));
-    state.read((char*)&cause, sizeof(cause));
-    state.read((char*)&EPC, sizeof(EPC));
-    state.read((char*)&ErrorEPC, sizeof(ErrorEPC));
-    state.read((char*)&PCCR, sizeof(PCCR));
-    state.read((char*)&PCR0, sizeof(PCR0));
-    state.read((char*)&PCR1, sizeof(PCR1));
-    state.read((char*)&tlb, sizeof(tlb));
+    state.DoArray(gpr, 32);
+    state.Do(&status);
+    state.Do(&cause);
+    state.Do(&EPC);
+    state.Do(&ErrorEPC);
+    state.Do(&PCCR);
+    state.Do(&PCR0);
+    state.Do(&PCR1);
+    state.DoArray(tlb, 48);
 
-    //Repopulate VTLB
-    for (int i = 0; i < 48; i++)
-        map_tlb(&tlb[i]);
+    if (state.GetMode() == StateSerializer::Mode::Read)
+    {
+        //Repopulate VTLB
+        for (int i = 0; i < 48; i++)
+            map_tlb(&tlb[i]);
+    }
 }
 
-void Cop0::save_state(ofstream &state)
+void Cop1::do_state(StateSerializer& state)
 {
-    state.write((char*)&gpr, sizeof(gpr));
-    state.write((char*)&status, sizeof(status));
-    state.write((char*)&cause, sizeof(cause));
-    state.write((char*)&EPC, sizeof(EPC));
-    state.write((char*)&ErrorEPC, sizeof(ErrorEPC));
-    state.write((char*)&PCCR, sizeof(PCCR));
-    state.write((char*)&PCR0, sizeof(PCR0));
-    state.write((char*)&PCR1, sizeof(PCR1));
-    state.write((char*)&tlb, sizeof(tlb));
+    //for (int i = 0; i < 32; i++)
+    //    state.read((char*)&gpr[i].u, sizeof(uint32_t));
+    state.DoArray(gpr, 32);
+    state.Do(&accumulator);
+    state.Do(&control);
 }
 
-void Cop1::load_state(ifstream &state)
+void IOP::do_state(StateSerializer& state)
 {
-    for (int i = 0; i < 32; i++)
-        state.read((char*)&gpr[i].u, sizeof(uint32_t));
-    state.read((char*)&accumulator.u, sizeof(uint32_t));
-    state.read((char*)&control, sizeof(control));
-}
+    state.DoArray(gpr, 32);
+    state.Do(&LO);
+    state.Do(&HI);
+    state.Do(&PC);
+    state.Do(&new_PC);
+    state.DoArray(icache, 256);
 
-void Cop1::save_state(ofstream &state)
-{
-    for (int i = 0; i < 32; i++)
-        state.write((char*)&gpr[i].u, sizeof(uint32_t));
-    state.write((char*)&accumulator.u, sizeof(uint32_t));
-    state.write((char*)&control, sizeof(control));
-}
-
-void IOP::load_state(ifstream &state)
-{
-    state.read((char*)&gpr, sizeof(gpr));
-    state.read((char*)&LO, sizeof(LO));
-    state.read((char*)&HI, sizeof(HI));
-    state.read((char*)&PC, sizeof(PC));
-    state.read((char*)&new_PC, sizeof(new_PC));
-    state.read((char*)&icache, sizeof(icache));
-
-    state.read((char*)&branch_delay, sizeof(branch_delay));
-    state.read((char*)&will_branch, sizeof(branch_delay));
-    state.read((char*)&wait_for_IRQ, sizeof(wait_for_IRQ));
+    state.Do(&branch_delay);
+    state.Do(&will_branch);
+    state.Do(&wait_for_IRQ);
 
     //COP0
-    state.read((char*)&cop0.status, sizeof(cop0.status));
-    state.read((char*)&cop0.cause, sizeof(cop0.cause));
-    state.read((char*)&cop0.EPC, sizeof(cop0.EPC));
+    state.Do(&cop0.status);
+    state.Do(&cop0.cause);
+    state.Do(&cop0.EPC);
 }
 
-void IOP::save_state(ofstream &state)
+void VectorUnit::do_state(StateSerializer& state)
 {
-    state.write((char*)&gpr, sizeof(gpr));
-    state.write((char*)&LO, sizeof(LO));
-    state.write((char*)&HI, sizeof(HI));
-    state.write((char*)&PC, sizeof(PC));
-    state.write((char*)&new_PC, sizeof(new_PC));
-    state.write((char*)&icache, sizeof(icache));
+    //for (int i = 0; i < 32; i++)
+    //    state.read((char*)&gpr[i].u, sizeof(uint32_t) * 4);
+    state.DoArray(gpr, 32);
+    state.DoArray(int_gpr, 16);
+    state.Do(&decoder);
 
-    state.write((char*)&branch_delay, sizeof(branch_delay));
-    state.write((char*)&will_branch, sizeof(branch_delay));
-    state.write((char*)&wait_for_IRQ, sizeof(wait_for_IRQ));
-
-    //COP0
-    state.write((char*)&cop0.status, sizeof(cop0.status));
-    state.write((char*)&cop0.cause, sizeof(cop0.cause));
-    state.write((char*)&cop0.EPC, sizeof(cop0.EPC));
-}
-
-void VectorUnit::load_state(ifstream &state)
-{
-    for (int i = 0; i < 32; i++)
-        state.read((char*)&gpr[i].u, sizeof(uint32_t) * 4);
-    state.read((char*)&int_gpr, sizeof(int_gpr));
-    state.read((char*)&decoder, sizeof(decoder));
-
-    state.read((char*)&ACC.u, sizeof(uint32_t) * 4);
-    state.read((char*)&R.u, sizeof(R.u));
-    state.read((char*)&I.u, sizeof(I.u));
-    state.read((char*)&Q.u, sizeof(Q.u));
-    state.read((char*)&P.u, sizeof(P.u));
-    state.read((char*)&CMSAR0, sizeof(CMSAR0));
+    state.Do(&ACC);
+    state.Do(&R);
+    state.Do(&I);
+    state.Do(&Q);
+    state.Do(&P);
+    state.Do(&CMSAR0);
 
     //Pipelines
-    state.read((char*)&new_MAC_flags, sizeof(new_MAC_flags));
-    state.read((char*)&MAC_pipeline, sizeof(MAC_pipeline));
-    state.read((char*)&cycle_count, sizeof(cycle_count));
-    state.read((char*)&finish_DIV_event, sizeof(finish_DIV_event));
-    state.read((char*)&new_Q_instance.u, sizeof(new_Q_instance.u));
-    state.read((char*)&DIV_event_started, sizeof(DIV_event_started));
-    state.read((char*)&finish_EFU_event, sizeof(finish_EFU_event));
-    state.read((char*)&new_P_instance.u, sizeof(new_P_instance.u));
-    state.read((char*)&EFU_event_started, sizeof(EFU_event_started));
+    state.Do(&new_MAC_flags);
+    state.DoArray(MAC_pipeline, 4);
+    state.Do(&cycle_count);
+    state.Do(&finish_DIV_event);
+    state.Do(&new_Q_instance);
+    state.Do(&DIV_event_started);
+    state.Do(&finish_EFU_event);
+    state.Do(&new_P_instance);
+    state.Do(&EFU_event_started);
 
-    state.read((char*)&int_branch_delay, sizeof(int_branch_delay));
-    state.read((char*)&int_backup_reg, sizeof(int_backup_reg));
-    state.read((char*)&int_backup_id, sizeof(int_backup_id));
+    state.Do(&int_branch_delay);
+    state.Do(&int_backup_reg);
+    state.Do(&int_backup_id);
 
-    state.read((char*)&status, sizeof(status));
-    state.read((char*)&status_value, sizeof(status_value));
-    state.read((char*)&status_pipe, sizeof(status_pipe));
-    state.read((char*)&int_branch_pipeline, sizeof(int_branch_pipeline));
-    state.read((char*)&ILW_pipeline, sizeof(ILW_pipeline));
+    state.Do(&status);
+    state.Do(&status_value);
+    state.Do(&status_pipe);
+    state.Do(&int_branch_pipeline);
+    state.DoArray(ILW_pipeline, 4);
 
-    state.read((char*)&pipeline_state, sizeof(pipeline_state));
+    state.DoArray(pipeline_state, 2);
 
     //XGKICK
-    state.read((char*)&GIF_addr, sizeof(GIF_addr));
-    state.read((char*)&transferring_GIF, sizeof(transferring_GIF));
-    state.read((char*)&XGKICK_stall, sizeof(XGKICK_stall));
-    state.read((char*)&stalled_GIF_addr, sizeof(stalled_GIF_addr));
+    state.Do(&GIF_addr);
+    state.Do(&transferring_GIF);
+    state.Do(&XGKICK_stall);
+    state.Do(&stalled_GIF_addr);
 
     //Memory
     if (id == 0)
     {
-        state.read((char*)&instr_mem, 1024 * 4);
-        state.read((char*)&data_mem, 1024 * 4);
+        state.DoBytes(&instr_mem, 1024 * 4);
+        state.DoBytes(&data_mem, 1024 * 4);
     }
     else
     {
-        state.read((char*)&instr_mem, 1024 * 16);
-        state.read((char*)&data_mem, 1024 * 16);
+        state.DoBytes(&instr_mem, 1024 * 16);
+        state.DoBytes(&data_mem, 1024 * 16);
     }
 
-    state.read((char*)&running, sizeof(running));
-    state.read((char*)&PC, sizeof(PC));
-    state.read((char*)&new_PC, sizeof(new_PC));
-    state.read((char*)&secondbranch_PC, sizeof(secondbranch_PC));
-    state.read((char*)&second_branch_pending, sizeof(second_branch_pending));
-    state.read((char*)&branch_on, sizeof(branch_on));
-    state.read((char*)&branch_on_delay, sizeof(branch_on_delay));
-    state.read((char*)&finish_on, sizeof(finish_on));
-    state.read((char*)&branch_delay_slot, sizeof(branch_delay_slot));
-    state.read((char*)&ebit_delay_slot, sizeof(ebit_delay_slot));
+    state.Do(&running);
+    state.Do(&PC);
+    state.Do(&new_PC);
+    state.Do(&secondbranch_PC);
+    state.Do(&second_branch_pending);
+    state.Do(&branch_on);
+    state.Do(&branch_on_delay);
+    state.Do(&finish_on);
+    state.Do(&branch_delay_slot);
+    state.Do(&ebit_delay_slot);
 }
 
-void VectorUnit::save_state(ofstream &state)
+void INTC::do_state(StateSerializer& state)
 {
-    for (int i = 0; i < 32; i++)
-        state.write((char*)&gpr[i].u, sizeof(uint32_t) * 4);
-    state.write((char*)&int_gpr, sizeof(int_gpr));
-    state.write((char*)&decoder, sizeof(decoder));
+    state.Do(&INTC_MASK);
+    state.Do(&INTC_STAT);
+    state.Do(&stat_speedhack_active);
+    state.Do(&read_stat_count);
+}
 
-    state.write((char*)&ACC.u, sizeof(uint32_t) * 4);
-    state.write((char*)&R.u, sizeof(R.u));
-    state.write((char*)&I.u, sizeof(I.u));
-    state.write((char*)&Q.u, sizeof(Q.u));
-    state.write((char*)&P.u, sizeof(P.u));
-    state.write((char*)&CMSAR0, sizeof(CMSAR0));
+void IOP_INTC::do_state(StateSerializer& state)
+{
+    state.Do(&I_CTRL);
+    state.Do(&I_STAT);
+    state.Do(&I_MASK);
+}
 
-    //Pipelines
-    state.write((char*)&new_MAC_flags, sizeof(new_MAC_flags));
-    state.write((char*)&MAC_pipeline, sizeof(MAC_pipeline));
-    state.write((char*)&cycle_count, sizeof(cycle_count));
-    state.write((char*)&finish_DIV_event, sizeof(finish_DIV_event));
-    state.write((char*)&new_Q_instance.u, sizeof(new_Q_instance.u));
-    state.write((char*)&DIV_event_started, sizeof(DIV_event_started));
-    state.write((char*)&finish_EFU_event, sizeof(finish_EFU_event));
-    state.write((char*)&new_P_instance.u, sizeof(new_P_instance.u));
-    state.write((char*)&EFU_event_started, sizeof(EFU_event_started));
+void EmotionTiming::do_state(StateSerializer& state)
+{
+    state.DoArray(timers, 4);
+    state.DoArray(events, 4);
+}
 
-    state.write((char*)&int_branch_delay, sizeof(int_branch_delay));
-    state.write((char*)&int_backup_reg, sizeof(int_backup_reg));
-    state.write((char*)&int_backup_id, sizeof(int_backup_id));
-    state.write((char*)&status, sizeof(status));
-    state.write((char*)&status_value, sizeof(status_value));
-    state.write((char*)&status_pipe, sizeof(status_pipe));
-    state.write((char*)&int_branch_pipeline, sizeof(int_branch_pipeline));
-    state.write((char*)&ILW_pipeline, sizeof(ILW_pipeline));
+void IOPTiming::do_state(StateSerializer& state)
+{
+    state.DoArray(timers, 6);
+}
 
-    state.write((char*)&pipeline_state, sizeof(pipeline_state));
+void DMAC::do_state(StateSerializer& state)
+{
+    state.DoArray(channels, 15);
 
-    //XGKICK
-    state.write((char*)&GIF_addr, sizeof(GIF_addr));
-    state.write((char*)&transferring_GIF, sizeof(transferring_GIF));
-    state.write((char*)&XGKICK_stall, sizeof(XGKICK_stall));
-    state.write((char*)&stalled_GIF_addr, sizeof(stalled_GIF_addr));
+    if (state.GetMode() == StateSerializer::Mode::Read)
+        apply_dma_funcs();
 
-    //Memory
-    if (id == 0)
+    state.Do(&control);
+    state.Do(&interrupt_stat);
+    state.Do(&PCR);
+    state.Do(&RBOR);
+    state.Do(&RBSR);
+    state.Do(&SQWC);
+    state.Do(&STADR);
+    state.Do(&mfifo_empty_triggered);
+    state.Do(&cycles_to_run);
+    state.Do(&master_disable);
+
+    int index = -1;
+
+    if (state.GetMode() == StateSerializer::Mode::Read)
     {
-        state.write((char*)&instr_mem, 1024 * 4);
-        state.write((char*)&data_mem, 1024 * 4);
+        state.Do(&index);
+        if (index >= 0)
+            active_channel = &channels[index];
+        else
+            active_channel = nullptr;
     }
     else
     {
-        state.write((char*)&instr_mem, 1024 * 16);
-        state.write((char*)&data_mem, 1024 * 16);
+        if (active_channel)
+            index = active_channel->index;
+        else
+            index = -1;
+
+        state.Do(&index);
     }
 
-    state.write((char*)&running, sizeof(running));
-    state.write((char*)&PC, sizeof(PC));
-    state.write((char*)&new_PC, sizeof(new_PC));
-    state.write((char*)&secondbranch_PC, sizeof(secondbranch_PC));
-    state.write((char*)&second_branch_pending, sizeof(second_branch_pending));
-    state.write((char*)&branch_on, sizeof(branch_on));
-    state.write((char*)&branch_on_delay, sizeof(branch_on_delay));
-    state.write((char*)&finish_on, sizeof(finish_on));
-    state.write((char*)&branch_delay_slot, sizeof(branch_delay_slot));
-    state.write((char*)&ebit_delay_slot, sizeof(ebit_delay_slot));
-}
-
-void INTC::load_state(ifstream &state)
-{
-    state.read((char*)&INTC_MASK, sizeof(INTC_MASK));
-    state.read((char*)&INTC_STAT, sizeof(INTC_STAT));
-    state.read((char*)&stat_speedhack_active, sizeof(stat_speedhack_active));
-    state.read((char*)&read_stat_count, sizeof(read_stat_count));
-}
-
-void INTC::save_state(ofstream &state)
-{
-    state.write((char*)&INTC_MASK, sizeof(INTC_MASK));
-    state.write((char*)&INTC_STAT, sizeof(INTC_STAT));
-    state.write((char*)&stat_speedhack_active, sizeof(stat_speedhack_active));
-    state.write((char*)&read_stat_count, sizeof(read_stat_count));
-}
-
-void IOP_INTC::load_state(ifstream &state)
-{
-    state.read((char*)&I_CTRL, sizeof(I_CTRL));
-    state.read((char*)&I_STAT, sizeof(I_STAT));
-    state.read((char*)&I_MASK, sizeof(I_MASK));
-}
-
-void IOP_INTC::save_state(ofstream &state)
-{
-    state.write((char*)&I_CTRL, sizeof(I_CTRL));
-    state.write((char*)&I_STAT, sizeof(I_STAT));
-    state.write((char*)&I_MASK, sizeof(I_MASK));
-}
-
-void EmotionTiming::load_state(ifstream &state)
-{
-    state.read((char*)&timers, sizeof(timers));
-    state.read((char*)&events, sizeof(events));
-}
-
-void EmotionTiming::save_state(ofstream &state)
-{
-    state.write((char*)&timers, sizeof(timers));
-    state.write((char*)&events, sizeof(events));
-}
-
-void IOPTiming::load_state(ifstream &state)
-{
-    state.read((char*)&timers, sizeof(timers));
-}
-
-void IOPTiming::save_state(ofstream &state)
-{
-    state.write((char*)&timers, sizeof(timers));
-}
-
-void DMAC::load_state(ifstream &state)
-{
-    state.read((char*)&channels, sizeof(channels));
-
-    apply_dma_funcs();
-
-    state.read((char*)&control, sizeof(control));
-    state.read((char*)&interrupt_stat, sizeof(interrupt_stat));
-    state.read((char*)&PCR, sizeof(PCR));
-    state.read((char*)&RBOR, sizeof(RBOR));
-    state.read((char*)&RBSR, sizeof(RBSR));
-    state.read((char*)&SQWC, sizeof(SQWC));
-    state.read((char*)&STADR, sizeof(STADR));
-    state.read((char*)&mfifo_empty_triggered, sizeof(mfifo_empty_triggered));
-    state.read((char*)&cycles_to_run, sizeof(cycles_to_run));
-    state.read((char*)&master_disable, sizeof(master_disable));
-
-    int index;
-    state.read((char*)&index, sizeof(index));
-    if (index >= 0)
-        active_channel = &channels[index];
-    else
-        active_channel = nullptr;
-
-    int queued_size;
-    state.read((char*)&queued_size, sizeof(queued_size));
-    if (queued_size > 0)
+    if (state.GetMode() == StateSerializer::Mode::Read)
     {
+        int queued_size;
+        state.Do(&queued_size);
+        if (queued_size > 0)
+        {
+            for (int i = 0; i < queued_size; i++)
+            {
+                state.Do(&index);
+                queued_channels.push_back(&channels[index]);
+            }
+        }
+    }
+    else
+    {
+        int size = queued_channels.size();
+        state.Do(&size);
+        if (size > 0)
+        {
+            for (auto it = queued_channels.begin(); it != queued_channels.end(); it++)
+            {
+                index = (*it)->index;
+                state.Do((&index));
+            }
+        }
+    }
+}
+
+void IOP_DMA::do_state(StateSerializer& state)
+{
+    state.Do(&channels);
+
+    if (state.GetMode() == StateSerializer::Mode::Read)
+    {
+        int active_index;
+        state.Do(&active_index);
+        if (active_index)
+            active_channel = &channels[active_index - 1];
+        else
+            active_channel = nullptr;
+    }
+    else
+    {
+        int active_index = 0;
+        if (active_channel)
+            active_index = active_channel->index + 1;
+        state.Do(&active_index);
+    }
+
+    if (state.GetMode() == StateSerializer::Mode::Read)
+    {
+        int queued_size = 0;
+        state.Do(&queued_size);
         for (int i = 0; i < queued_size; i++)
         {
-            state.read((char*)&index, sizeof(index));
+            int index;
+            state.Do(&index);
             queued_channels.push_back(&channels[index]);
         }
     }
-}
-
-void DMAC::save_state(ofstream &state)
-{
-    state.write((char*)&channels, sizeof(channels));
-
-    state.write((char*)&control, sizeof(control));
-    state.write((char*)&interrupt_stat, sizeof(interrupt_stat));
-    state.write((char*)&PCR, sizeof(PCR));
-    state.write((char*)&RBOR, sizeof(RBOR));
-    state.write((char*)&RBSR, sizeof(RBSR));
-    state.write((char*)&SQWC, sizeof(SQWC));
-    state.write((char*)&STADR, sizeof(STADR));
-    state.write((char*)&mfifo_empty_triggered, sizeof(mfifo_empty_triggered));
-    state.write((char*)&cycles_to_run, sizeof(cycles_to_run));
-    state.write((char*)&master_disable, sizeof(master_disable));
-
-    int index;
-    if (active_channel)
-        index = active_channel->index;
     else
-        index = -1;
-
-    state.write((char*)&index, sizeof(index));
-    int size = queued_channels.size();
-    state.write((char*)&size, sizeof(size));
-    if (size > 0)
     {
-        for (auto it = queued_channels.begin(); it != queued_channels.end(); it++ )
+        int queued_size = static_cast<int>(queued_channels.size());
+        state.Do(&queued_size);
+        for (auto it = queued_channels.begin(); it != queued_channels.end(); it++)
         {
-            index = (*it)->index;
-            state.write((char*)&index, sizeof(index));
+            IOP_DMA_Channel* chan = *it;
+            state.Do(&chan->index);
         }
     }
-}
 
-void IOP_DMA::load_state(ifstream &state)
-{
-    state.read((char*)&channels, sizeof(channels));
-
-    int active_index;
-    state.read((char*)&active_index, sizeof(active_index));
-    if (active_index)
-        active_channel = &channels[active_index - 1];
-    else
-        active_channel = nullptr;
-
-    int queued_size = 0;
-    state.read((char*)&queued_size, sizeof(queued_size));
-    for (int i = 0; i < queued_size; i++)
-    {
-        int index;
-        state.read((char*)&index, sizeof(index));
-        queued_channels.push_back(&channels[index]);
-    }
-
-    state.read((char*)&DPCR, sizeof(DPCR));
-    state.read((char*)&DICR, sizeof(DICR));
+    state.Do(&DPCR);
+    state.Do(&DICR);
 
     //We have to reapply the function pointers as there's no guarantee they will remain in memory
     //the next time Dobie is loaded
-    apply_dma_functions();
+    if (state.GetMode() == StateSerializer::Mode::Read)
+        apply_dma_functions();
 }
 
-void IOP_DMA::save_state(ofstream &state)
+void GraphicsInterface::do_state(StateSerializer& state)
 {
-    state.write((char*)&channels, sizeof(channels));
+    state.Do(&FIFO);
 
-    int active_index = 0;
-    if (active_channel)
-        active_index = active_channel->index + 1;
-    state.write((char*)&active_index, sizeof(active_index));
-
-    int queued_size = queued_channels.size();
-    state.write((char*)&queued_size, sizeof(queued_size));
-    for (auto it = queued_channels.begin(); it != queued_channels.end(); it++)
-    {
-        IOP_DMA_Channel* chan = *it;
-        state.write((char*)&chan->index, sizeof(chan->index));
-    }
-
-    state.write((char*)&DPCR, sizeof(DPCR));
-    state.write((char*)&DICR, sizeof(DICR));
+    state.Do(&path);
+    state.Do(&active_path);
+    state.Do(&path_queue);
+    state.Do(&path3_vif_masked);
+    state.Do(&internal_Q);
+    state.Do(&path3_dma_running);
+    state.Do(&intermittent_mode);
+    state.Do(&outputting_path);
+    state.Do(&path3_mode_masked);
+    state.Do(&gif_temporary_stop);
 }
 
-void GraphicsInterface::load_state(ifstream &state)
+void SubsystemInterface::do_state(StateSerializer& state)
 {
-    int size;
-    uint128_t FIFO_buffer[16];
-    state.read((char*)&size, sizeof(size));
-    state.read((char*)&FIFO_buffer, sizeof(uint128_t) * size);
-    for (int i = 0; i < size; i++)
-        FIFO.push(FIFO_buffer[i]);
-
-    state.read((char*)&path, sizeof(path));
-    state.read((char*)&active_path, sizeof(active_path));
-    state.read((char*)&path_queue, sizeof(path_queue));
-    state.read((char*)&path3_vif_masked, sizeof(path3_vif_masked));
-    state.read((char*)&internal_Q, sizeof(internal_Q));
-    state.read((char*)&path3_dma_running, sizeof(path3_dma_running));
-    state.read((char*)&intermittent_mode, sizeof(intermittent_mode));
-    state.read((char*)&outputting_path, sizeof(outputting_path));
-    state.read((char*)&path3_mode_masked, sizeof(path3_mode_masked));
-    state.read((char*)&gif_temporary_stop, sizeof(gif_temporary_stop));
+    state.Do(&mscom);
+    state.Do(&smcom);
+    state.Do(&msflag);
+    state.Do(&smflag);
+    state.Do(&control);
+    state.Do(&SIF0_FIFO);
+    state.Do(&SIF1_FIFO);
 }
 
-void GraphicsInterface::save_state(ofstream &state)
+void VectorInterface::do_state(StateSerializer& state)
 {
-    int size = FIFO.size();
-    uint128_t FIFO_buffer[16];
-    for (int i = 0; i < size; i++)
-    {
-        FIFO_buffer[i] = FIFO.front();
-        FIFO.pop();
-    }
-    state.write((char*)&size, sizeof(size));
-    state.write((char*)&FIFO_buffer, sizeof(uint128_t) * size);
-    for (int i = 0; i < size; i++)
-        FIFO.push(FIFO_buffer[i]);
+    state.Do(&FIFO);
+    state.Do(&internal_FIFO);
 
-    state.write((char*)&path, sizeof(path));
-    state.write((char*)&active_path, sizeof(active_path));
-    state.write((char*)&path_queue, sizeof(path_queue));
-    state.write((char*)&path3_vif_masked, sizeof(path3_vif_masked));
-    state.write((char*)&internal_Q, sizeof(internal_Q));
-    state.write((char*)&path3_dma_running, sizeof(path3_dma_running));
-    state.write((char*)&intermittent_mode, sizeof(intermittent_mode));
-    state.write((char*)&outputting_path, sizeof(outputting_path));
-    state.write((char*)&path3_mode_masked, sizeof(path3_mode_masked));
-    state.write((char*)&gif_temporary_stop, sizeof(gif_temporary_stop));
+    state.Do(&imm);
+    state.Do(&command);
+    state.Do(&mpg);
+    state.Do(&unpack);
+    state.Do(&wait_for_VU);
+    state.Do(&flush_stall);
+    state.Do(&wait_cmd_value);
+    state.Do(&buffer_size);
+    state.DoArray(buffer, 4);
+
+    state.Do(&DBF);
+    state.Do(&CYCLE);
+    state.Do(&OFST);
+    state.Do(&BASE);
+    state.Do(&TOP);
+    state.Do(&TOPS);
+    state.Do(&ITOP);
+    state.Do(&ITOPS);
+    state.Do(&MODE);
+    state.Do(&MASK);
+    state.DoArray(ROW, 4);
+    state.DoArray(COL, 4);
+    state.Do(&CODE);
+    state.Do(&command_len);
+
+    state.Do(&vif_ibit_detected);
+    state.Do(&vif_interrupt);
+    state.Do(&vif_stalled);
+    state.Do(&vif_stop);
+    state.Do(&vif_forcebreak);
+    state.Do(&vif_cmd_status);
+    state.Do(&internal_WL);
+
+    state.Do(&mark_detected);
+    state.Do(&VIF_ERR);
 }
 
-void SubsystemInterface::load_state(ifstream &state)
+void CDVD_Drive::do_state(StateSerializer& state)
 {
-    state.read((char*)&mscom, sizeof(mscom));
-    state.read((char*)&smcom, sizeof(smcom));
-    state.read((char*)&msflag, sizeof(msflag));
-    state.read((char*)&smflag, sizeof(smflag));
-    state.read((char*)&control, sizeof(control));
+    state.Do(&file_size);
+    state.Do(&read_bytes_left);
+    state.Do(&disc_type);
+    state.Do(&speed);
+    state.Do(&current_sector);
+    state.Do(&sector_pos);
+    state.Do(&sectors_left);
+    state.Do(&block_size);
+    state.DoBytes(read_buffer, 4096);
+    state.Do(&ISTAT);
+    state.Do(&drive_status);
+    state.Do(&is_spinning);
 
-    int size;
-    uint32_t buffer[32];
-    state.read((char*)&size, sizeof(int));
-    state.read((char*)&buffer, sizeof(uint32_t) * size);
+    state.Do(&active_N_command);
+    state.Do(&N_command);
+    state.DoArray(N_command_params, 11);
+    state.Do(&N_params);
+    state.Do(&N_status);
 
-    //FIFOs are already cleared by the reset call, so no need to pop them
-    for (int i = 0; i < size; i++)
-        SIF0_FIFO.push(buffer[i]);
-
-    state.read((char*)&size, sizeof(int));
-    state.read((char*)&buffer, sizeof(uint32_t) * size);
-
-    for (int i = 0; i < size; i++)
-        SIF1_FIFO.push(buffer[i]);
+    state.Do(&S_command);
+    state.DoArray(S_command_params, 16);
+    state.DoArray(S_outdata, 16);
+    state.Do(&S_params);
+    state.Do(&S_out_params);
+    state.Do(&S_status);
+    state.Do(&rtc);
 }
 
-void SubsystemInterface::save_state(ofstream &state)
+void Scheduler::do_state(StateSerializer& state)
 {
-    state.write((char*)&mscom, sizeof(mscom));
-    state.write((char*)&smcom, sizeof(smcom));
-    state.write((char*)&msflag, sizeof(msflag));
-    state.write((char*)&smflag, sizeof(smflag));
-    state.write((char*)&control, sizeof(control));
+    state.Do(&ee_cycles);
+    state.Do(&bus_cycles);
+    state.Do(&iop_cycles);
+    state.Do(&run_cycles);
+    state.Do(&closest_event_time);
 
-    int size = SIF0_FIFO.size();
-    uint32_t buffer[32];
-    for (int i = 0; i < size; i++)
-    {
-        buffer[i] = SIF0_FIFO.front();
-        SIF0_FIFO.pop();
-    }
-    state.write((char*)&size, sizeof(int));
-    state.write((char*)&buffer, sizeof(uint32_t) * size);
-    for (int i = 0; i < size; i++)
-        SIF0_FIFO.push(buffer[i]);
-
-    size = SIF1_FIFO.size();
-    for (int i = 0; i < size; i++)
-    {
-        buffer[i] = SIF1_FIFO.front();
-        SIF1_FIFO.pop();
-    }
-    state.write((char*)&size, sizeof(int));
-    state.write((char*)&buffer, sizeof(uint32_t) * size);
-    for (int i = 0; i < size; i++)
-        SIF1_FIFO.push(buffer[i]);
+    state.Do(&events);
+    state.Do(&timers);
 }
 
-void VectorInterface::load_state(ifstream &state)
+void Gamepad::do_state(StateSerializer& state)
 {
-    int size, internal_size;
-    uint32_t FIFO_buffer[64];
-    state.read((char*)&size, sizeof(size));
-    state.read((char*)&FIFO_buffer, sizeof(uint32_t) * size);
-    for (int i = 0; i < size; i++)
-        FIFO.push(FIFO_buffer[i]);
-
-    state.read((char*)&internal_size, sizeof(internal_size));
-    state.read((char*)&FIFO_buffer, sizeof(uint32_t) * internal_size);
-    for (int i = 0; i < internal_size; i++)
-        internal_FIFO.push(FIFO_buffer[i]);
-
-    state.read((char*)&imm, sizeof(imm));
-    state.read((char*)&command, sizeof(command));
-    state.read((char*)&mpg, sizeof(mpg));
-    state.read((char*)&unpack, sizeof(unpack));
-    state.read((char*)&wait_for_VU, sizeof(wait_for_VU));
-    state.read((char*)&flush_stall, sizeof(flush_stall));
-    state.read((char*)&wait_cmd_value, sizeof(wait_cmd_value));
-
-    state.read((char*)&buffer_size, sizeof(buffer_size));
-    state.read((char*)&buffer, sizeof(buffer));
-
-    state.read((char*)&DBF, sizeof(DBF));
-    state.read((char*)&CYCLE, sizeof(CYCLE));
-    state.read((char*)&OFST, sizeof(OFST));
-    state.read((char*)&BASE, sizeof(BASE));
-    state.read((char*)&TOP, sizeof(TOP));
-    state.read((char*)&TOPS, sizeof(TOPS));
-    state.read((char*)&ITOP, sizeof(ITOP));
-    state.read((char*)&ITOPS, sizeof(ITOPS));
-    state.read((char*)&MODE, sizeof(MODE));
-    state.read((char*)&MASK, sizeof(MASK));
-    state.read((char*)&ROW, sizeof(ROW));
-    state.read((char*)&COL, sizeof(COL));
-    state.read((char*)&CODE, sizeof(CODE));
-    state.read((char*)&command_len, sizeof(command_len));
-
-    state.read((char*)&vif_ibit_detected, sizeof(vif_ibit_detected));
-    state.read((char*)&vif_interrupt, sizeof(vif_interrupt));
-    state.read((char*)&vif_stalled, sizeof(vif_stalled));
-    state.read((char*)&vif_stop, sizeof(vif_stop));
-    state.read((char*)&vif_forcebreak, sizeof(vif_forcebreak));
-    state.read((char*)&vif_cmd_status, sizeof(vif_cmd_status));
-    state.read((char*)&internal_WL, sizeof(internal_WL));
-
-    state.read((char*)&mark_detected, sizeof(mark_detected));
-    state.read((char*)&VIF_ERR, sizeof(VIF_ERR));
+    state.DoArray(command_buffer, 25);
+    state.DoArray(rumble_values, 8);
+    state.Do(&mode_lock);
+    state.Do(&command);
+    state.Do(&command_length);
+    state.Do(&data_count);
+    state.Do(&pad_mode);
+    state.Do(&config_mode);
 }
 
-void VectorInterface::save_state(ofstream &state)
+void SPU::do_state(StateSerializer& state)
 {
-    int size = FIFO.size();
-    int internal_size = internal_FIFO.size();
-    uint32_t FIFO_buffer[64];
-    for (int i = 0; i < size; i++)
-    {
-        FIFO_buffer[i] = FIFO.front();
-        FIFO.pop();
-    }
-    state.write((char*)&size, sizeof(size));
-    state.write((char*)&FIFO_buffer, sizeof(uint32_t) * size);
-    for (int i = 0; i < size; i++)
-        FIFO.push(FIFO_buffer[i]);
-
-    for (int i = 0; i < internal_size; i++)
-    {
-        FIFO_buffer[i] = internal_FIFO.front();
-        internal_FIFO.pop();
-    }
-    state.write((char*)&internal_size, sizeof(internal_size));
-    state.write((char*)&FIFO_buffer, sizeof(uint32_t) * internal_size);
-    for (int i = 0; i < internal_size; i++)
-        internal_FIFO.push(FIFO_buffer[i]);
-
-    state.write((char*)&imm, sizeof(imm));
-    state.write((char*)&command, sizeof(command));
-    state.write((char*)&mpg, sizeof(mpg));
-    state.write((char*)&unpack, sizeof(unpack));
-    state.write((char*)&wait_for_VU, sizeof(wait_for_VU));
-    state.write((char*)&flush_stall, sizeof(flush_stall));
-    state.write((char*)&wait_cmd_value, sizeof(wait_cmd_value));
-
-    state.write((char*)&buffer_size, sizeof(buffer_size));
-    state.write((char*)&buffer, sizeof(buffer));
-
-    state.write((char*)&DBF, sizeof(DBF));
-    state.write((char*)&CYCLE, sizeof(CYCLE));
-    state.write((char*)&OFST, sizeof(OFST));
-    state.write((char*)&BASE, sizeof(BASE));
-    state.write((char*)&TOP, sizeof(TOP));
-    state.write((char*)&TOPS, sizeof(TOPS));
-    state.write((char*)&ITOP, sizeof(ITOP));
-    state.write((char*)&ITOPS, sizeof(ITOPS));
-    state.write((char*)&MODE, sizeof(MODE));
-    state.write((char*)&MASK, sizeof(MASK));
-    state.write((char*)&ROW, sizeof(ROW));
-    state.write((char*)&COL, sizeof(COL));
-    state.write((char*)&CODE, sizeof(CODE));
-    state.write((char*)&command_len, sizeof(command_len));
-
-    state.write((char*)&vif_ibit_detected, sizeof(vif_ibit_detected));
-    state.write((char*)&vif_interrupt, sizeof(vif_interrupt));
-    state.write((char*)&vif_stalled, sizeof(vif_stalled));
-    state.write((char*)&vif_stop, sizeof(vif_stop));
-    state.write((char*)&vif_forcebreak, sizeof(vif_forcebreak));
-    state.write((char*)&vif_cmd_status, sizeof(vif_cmd_status));
-    state.write((char*)&internal_WL, sizeof(internal_WL));
-
-    state.write((char*)&mark_detected, sizeof(mark_detected));
-    state.write((char*)&VIF_ERR, sizeof(VIF_ERR));
-}
-
-void CDVD_Drive::load_state(ifstream &state)
-{
-    state.read((char*)&file_size, sizeof(file_size));
-    state.read((char*)&read_bytes_left, sizeof(read_bytes_left));
-    state.read((char*)&disc_type, sizeof(disc_type));
-    state.read((char*)&speed, sizeof(speed));
-    state.read((char*)&current_sector, sizeof(current_sector));
-    state.read((char*)&sector_pos, sizeof(sector_pos));
-    state.read((char*)&sectors_left, sizeof(sectors_left));
-    state.read((char*)&block_size, sizeof(block_size));
-    state.read((char*)&read_buffer, sizeof(read_buffer));
-    state.read((char*)&ISTAT, sizeof(ISTAT));
-    state.read((char*)&drive_status, sizeof(drive_status));
-    state.read((char*)&is_spinning, sizeof(is_spinning));
-
-    state.read((char*)&active_N_command, sizeof(active_N_command));
-    state.read((char*)&N_command, sizeof(N_command));
-    state.read((char*)&N_command_params, sizeof(N_command_params));
-    state.read((char*)&N_params, sizeof(N_params));
-    state.read((char*)&N_status, sizeof(N_status));
-
-    state.read((char*)&S_command, sizeof(S_command));
-    state.read((char*)&S_command_params, sizeof(S_command_params));
-    state.read((char*)&S_outdata, sizeof(S_outdata));
-    state.read((char*)&S_params, sizeof(S_params));
-    state.read((char*)&S_out_params, sizeof(S_out_params));
-    state.read((char*)&S_status, sizeof(S_status));
-    state.read((char*)&rtc, sizeof(rtc));
-}
-
-void CDVD_Drive::save_state(ofstream &state)
-{
-    state.write((char*)&file_size, sizeof(file_size));
-    state.write((char*)&read_bytes_left, sizeof(read_bytes_left));
-    state.write((char*)&disc_type, sizeof(disc_type));
-    state.write((char*)&speed, sizeof(speed));
-    state.write((char*)&current_sector, sizeof(current_sector));
-    state.write((char*)&sector_pos, sizeof(sector_pos));
-    state.write((char*)&sectors_left, sizeof(sectors_left));
-    state.write((char*)&block_size, sizeof(block_size));
-    state.write((char*)&read_buffer, sizeof(read_buffer));
-    state.write((char*)&ISTAT, sizeof(ISTAT));
-    state.write((char*)&drive_status, sizeof(drive_status));
-    state.write((char*)&is_spinning, sizeof(is_spinning));
-
-    state.write((char*)&active_N_command, sizeof(active_N_command));
-    state.write((char*)&N_command, sizeof(N_command));
-    state.write((char*)&N_command_params, sizeof(N_command_params));
-    state.write((char*)&N_params, sizeof(N_params));
-    state.write((char*)&N_status, sizeof(N_status));
-
-    state.write((char*)&S_command, sizeof(S_command));
-    state.write((char*)&S_command_params, sizeof(S_command_params));
-    state.write((char*)&S_outdata, sizeof(S_outdata));
-    state.write((char*)&S_params, sizeof(S_params));
-    state.write((char*)&S_out_params, sizeof(S_out_params));
-    state.write((char*)&S_status, sizeof(S_status));
-    state.write((char*)&rtc, sizeof(rtc));
-}
-
-void Scheduler::load_state(ifstream &state)
-{
-    state.read((char*)&ee_cycles, sizeof(ee_cycles));
-    state.read((char*)&bus_cycles, sizeof(bus_cycles));
-    state.read((char*)&iop_cycles, sizeof(iop_cycles));
-    state.read((char*)&run_cycles, sizeof(run_cycles));
-    state.read((char*)&closest_event_time, sizeof(closest_event_time));
-
-    events.clear();
-
-    int event_size = 0;
-    state.read((char*)&event_size, sizeof(event_size));
-
-    for (int i = 0; i < event_size; i++)
-    {
-        SchedulerEvent event;
-        state.read((char*)&event, sizeof(event));
-
-        events.push_back(event);
-    }
-
-    state.read((char*)&next_event_id, sizeof(next_event_id));
-
-    int timer_size = 0;
-    state.read((char*)&timer_size, sizeof(timer_size));
-
-    timers.clear();
-
-    for (int i = 0; i < timer_size; i++)
-    {
-        SchedulerTimer timer;
-        state.read((char*)&timer, sizeof(timer));
-
-        timers.push_back(timer);
-    }
-}
-
-void Scheduler::save_state(ofstream &state)
-{
-    state.write((char*)&ee_cycles, sizeof(ee_cycles));
-    state.write((char*)&bus_cycles, sizeof(bus_cycles));
-    state.write((char*)&iop_cycles, sizeof(iop_cycles));
-    state.write((char*)&run_cycles, sizeof(run_cycles));
-    state.write((char*)&closest_event_time, sizeof(closest_event_time));
-
-    int event_size = events.size();
-    state.write((char*)&event_size, sizeof(event_size));
-
-    for (auto it = events.begin(); it != events.end(); it++)
-    {
-        SchedulerEvent event = *it;
-        state.write((char*)&event, sizeof(event));
-    }
-
-    state.write((char*)&next_event_id, sizeof(next_event_id));
-
-    int timer_size = timers.size();
-    state.write((char*)&timer_size, sizeof(timer_size));
-
-    for (int i = 0; i < timer_size; i++)
-        state.write((char*)&timers[i], sizeof(SchedulerTimer));
-}
-
-void Gamepad::load_state(ifstream &state)
-{
-    state.read((char*)&command_buffer, sizeof(command_buffer));
-    state.read((char*)&rumble_values, sizeof(rumble_values));
-    state.read((char*)&mode_lock, sizeof(mode_lock));
-    state.read((char*)&command, sizeof(command));
-    state.read((char*)&command_length, sizeof(command_length));
-    state.read((char*)&data_count, sizeof(data_count));
-    state.read((char*)&pad_mode, sizeof(pad_mode));
-    state.read((char*)&config_mode, sizeof(config_mode));
-}
-
-void Gamepad::save_state(ofstream &state)
-{
-    state.write((char*)&command_buffer, sizeof(command_buffer));
-    state.write((char*)&rumble_values, sizeof(rumble_values));
-    state.write((char*)&mode_lock, sizeof(mode_lock));
-    state.write((char*)&command, sizeof(command));
-    state.write((char*)&command_length, sizeof(command_length));
-    state.write((char*)&data_count, sizeof(data_count));
-    state.write((char*)&pad_mode, sizeof(pad_mode));
-    state.write((char*)&config_mode, sizeof(config_mode));
-}
-
-void SPU::load_state(ifstream &state)
-{
-    state.read((char*)&voices, sizeof(voices));
-    state.read((char*)&core_att, sizeof(core_att));
-    state.read((char*)&status, sizeof(status));
-    state.read((char*)&spdif_irq, sizeof(spdif_irq));
-    state.read((char*)&transfer_addr, sizeof(transfer_addr));
-    state.read((char*)&current_addr, sizeof(current_addr));
-    state.read((char*)&autodma_ctrl, sizeof(autodma_ctrl));
-    state.read((char*)&buffer_pos, sizeof(buffer_pos));
-    state.read((char*)&IRQA, sizeof(IRQA));
-    state.read((char*)&ENDX, sizeof(ENDX));
-    state.read((char*)&key_off, sizeof(key_off));
-    state.read((char*)&key_on, sizeof(key_on));
-    state.read((char*)&noise, sizeof(noise));
-    state.read((char*)&output_enable, sizeof(output_enable));
-
-    state.read((char*)&reverb, sizeof(reverb));
-    state.read((char*)&effect_enable, sizeof(effect_enable));
-    state.read((char*)&effect_volume_l, sizeof(effect_volume_l));
-    state.read((char*)&effect_volume_r, sizeof(effect_volume_r));
-
-    state.read((char*)&current_buffer, sizeof(current_buffer));
-    state.read((char*)&ADMA_progress, sizeof(ADMA_progress));
-    state.read((char*)&data_input_volume_l, sizeof(data_input_volume_l));
-    state.read((char*)&data_input_volume_r, sizeof(data_input_volume_r));
-    state.read((char*)&core_volume_l, sizeof(core_volume_l));
-    state.read((char*)&core_volume_r, sizeof(core_volume_r));
-    state.read((char*)&MVOLL, sizeof(MVOLL));
-    state.read((char*)&MVOLR, sizeof(MVOLR));
-
-    state.read((char*)&mix_state, sizeof(mix_state));
-    state.read((char*)&voice_mixdry_left, sizeof(voice_mixdry_left));
-    state.read((char*)&voice_mixdry_right, sizeof(voice_mixdry_right));
-    state.read((char*)&voice_mixwet_left, sizeof(voice_mixwet_left));
-    state.read((char*)&voice_mixwet_right, sizeof(voice_mixwet_right));
-    state.read((char*)&voice_pitch_mod, sizeof(voice_pitch_mod));
-    state.read((char*)&voice_noise_gen, sizeof(voice_noise_gen));
-}
-
-void SPU::save_state(ofstream &state)
-{
-    state.write((char*)&voices, sizeof(voices));
-    state.write((char*)&core_att, sizeof(core_att));
-    state.write((char*)&status, sizeof(status));
-    state.write((char*)&spdif_irq, sizeof(spdif_irq));
-    state.write((char*)&transfer_addr, sizeof(transfer_addr));
-    state.write((char*)&current_addr, sizeof(current_addr));
-    state.write((char*)&autodma_ctrl, sizeof(autodma_ctrl));
-    state.write((char*)&buffer_pos, sizeof(buffer_pos));
-    state.write((char*)&IRQA, sizeof(IRQA));
-    state.write((char*)&ENDX, sizeof(ENDX));
-    state.write((char*)&key_off, sizeof(key_off));
-    state.write((char*)&key_on, sizeof(key_on));
-    state.write((char*)&noise, sizeof(noise));
-    state.write((char*)&output_enable, sizeof(output_enable));
-
-    state.write((char*)&reverb, sizeof(reverb));
-    state.write((char*)&effect_enable, sizeof(effect_enable));
-    state.write((char*)&effect_volume_l, sizeof(effect_volume_l));
-    state.write((char*)&effect_volume_r, sizeof(effect_volume_r));
-
-    state.write((char*)&current_buffer, sizeof(current_buffer));
-    state.write((char*)&ADMA_progress, sizeof(ADMA_progress));
-    state.write((char*)&data_input_volume_l, sizeof(data_input_volume_l));
-    state.write((char*)&data_input_volume_r, sizeof(data_input_volume_r));
-    state.write((char*)&core_volume_l, sizeof(core_volume_l));
-    state.write((char*)&core_volume_r, sizeof(core_volume_r));
-    state.write((char*)&MVOLL, sizeof(MVOLL));
-    state.write((char*)&MVOLR, sizeof(MVOLR));
-
-    state.write((char*)&mix_state, sizeof(mix_state));
-    state.write((char*)&voice_mixdry_left, sizeof(voice_mixdry_left));
-    state.write((char*)&voice_mixdry_right, sizeof(voice_mixdry_right));
-    state.write((char*)&voice_mixwet_left, sizeof(voice_mixwet_left));
-    state.write((char*)&voice_mixwet_right, sizeof(voice_mixwet_right));
-    state.write((char*)&voice_pitch_mod, sizeof(voice_pitch_mod));
-    state.write((char*)&voice_noise_gen, sizeof(voice_noise_gen));
+    state.DoArray(voices, 24);
+    state.DoArray(core_att, 2);
+    state.Do(&status);
+    state.Do(&spdif_irq);
+    state.Do(&transfer_addr);
+    state.Do(&current_addr);
+    state.Do(&autodma_ctrl);
+    state.Do(&buffer_pos);
+    state.DoArray(IRQA, 2);
+    state.Do(&ENDX);
+    state.Do(&key_off);
+    state.Do(&key_on);
+    state.Do(&noise);
+    state.Do(&output_enable);
+    state.Do(&reverb);
+    state.Do(&effect_enable);
+    state.Do(&effect_volume_l);
+    state.Do(&effect_volume_r);
+    state.Do(&current_buffer);
+    state.Do(&ADMA_progress);
+    state.Do(&data_input_volume_l);
+    state.Do(&data_input_volume_r);
+    state.Do(&core_volume_l);
+    state.Do(&core_volume_r);
+    state.Do(&MVOLL);
+    state.Do(&MVOLR);
+    state.Do(&mix_state);
+    state.Do(&voice_mixdry_left);
+    state.Do(&voice_mixdry_right);
+    state.Do(&voice_mixwet_left);
+    state.Do(&voice_mixwet_right);
+    state.Do(&voice_pitch_mod);
+    state.Do(&voice_noise_gen);
 }

--- a/src/core/serialize.hpp
+++ b/src/core/serialize.hpp
@@ -1,0 +1,139 @@
+#ifndef __SERIALIZE_H_
+#define __SERIALIZE_H_
+#include <cstring>
+#include <fstream>
+#include <list>
+#include <memory>
+#include <queue>
+#include <vector>
+
+class StateSerializer
+{
+  public:
+    enum class Mode
+    {
+        Read,
+        Write,
+    };
+
+    StateSerializer(std::fstream& stream, Mode mode) : m_stream(stream), m_mode(mode)
+    {
+    }
+
+    //~StateSerializer();
+
+    Mode GetMode() { return m_mode; };
+
+    template <typename T>
+    void Do(T* ptr)
+    {
+        if (m_mode == Mode::Read)
+        {
+            m_stream.read((char*)ptr, sizeof(T));
+        }
+        else
+        {
+            m_stream.write((char*)ptr, sizeof(T));
+        }
+    }
+
+    template <typename T>
+    void DoBytes(T* ptr, size_t len)
+    {
+        if (m_mode == Mode::Read)
+        {
+            m_stream.read((char*)ptr, len);
+        }
+        else
+        {
+            m_stream.write((char*)ptr, len);
+        }
+    }
+
+    template <typename T>
+    void Do(std::queue<T>* data)
+    {
+        uint32_t length = static_cast<uint32_t>(data->size());
+        Do(&length);
+        if (m_mode == Mode::Read)
+        {
+            // Doesn't reset
+            for (uint32_t i = 0; i < length; i++)
+            {
+                T value;
+                Do(&value);
+                data->push(value);
+            }
+        }
+        else
+        {
+            for (uint32_t i = 0; i < length; i++)
+                Do(&data[i]);
+        }
+    }
+
+    template <typename T>
+    void Do(std::list<T>* data)
+    {
+        uint32_t length = static_cast<uint32_t>(data->size());
+        Do(&length);
+        if (m_mode == Mode::Read)
+        {
+            data->clear();
+            for (uint32_t i = 0; i < length; i++)
+            {
+                T value;
+                Do(&value);
+                data->push_back(value);
+            }
+        }
+        else
+        {
+            for (auto it = data->begin(); it != data->end(); it++)
+            {
+                T value = *it;
+                Do((&value));
+            }
+        }
+    }
+
+    template <typename T>
+    void Do(std::vector<T>* data)
+    {
+        uint32_t length = static_cast<uint32_t>(data->size());
+        Do(&length);
+        if (m_mode == Mode::Read)
+            data->resize(length);
+        DoArray(data->data(), data->size());
+    }
+
+    template <typename T>
+    void DoArray(T* ptr, size_t count)
+    {
+        for (size_t i = 0; i < count; i++)
+        {
+            Do(&ptr[i]);
+        }
+    }
+
+    bool DoMarker(const char* marker)
+    {
+        auto len = strlen(marker);
+        auto fileVal = std::make_unique<char[]>(len);
+        memcpy(fileVal.get(), marker, len);
+        DoArray(fileVal.get(), len);
+
+        if (m_mode == Mode::Write || memcmp(marker, fileVal.get(), len) == 0)
+            return true;
+
+        fprintf(stderr, "Savestate marker mismatch: found '%s' expected '%s'\n", fileVal.get(), marker);
+
+        return false;
+    }
+
+  private:
+    Mode m_mode;
+    std::fstream& m_stream;
+};
+
+#endif // __SERIALIZE_H_

--- a/src/core/sif.hpp
+++ b/src/core/sif.hpp
@@ -6,6 +6,7 @@
 #include <list>
 #include <queue>
 
+#include "core/serialize.hpp"
 #include "int128.hpp"
 
 class IOP_DMA;
@@ -75,18 +76,17 @@ class SubsystemInterface
 
         void ee_log_sifrpc(uint32_t transfer_ptr, int len);
 
-        void load_state(std::ifstream& state);
-        void save_state(std::ofstream& state);
+        void do_state(StateSerializer& state);
 };
 
 inline int SubsystemInterface::get_SIF0_size()
 {
-    return SIF0_FIFO.size();
+    return static_cast<int>(SIF0_FIFO.size());
 }
 
 inline int SubsystemInterface::get_SIF1_size()
 {
-    return SIF1_FIFO.size();
+    return static_cast<int>(SIF1_FIFO.size());
 }
 
 #endif // SIF_HPP

--- a/src/core/sif.hpp
+++ b/src/core/sif.hpp
@@ -6,7 +6,7 @@
 #include <list>
 #include <queue>
 
-#include "core/serialize.hpp"
+#include "serialize.hpp"
 #include "int128.hpp"
 
 class IOP_DMA;

--- a/src/qt/emuthread.cpp
+++ b/src/qt/emuthread.cpp
@@ -117,7 +117,7 @@ bool EmuThread::gsdump_read(const char *name)
         if (!gsdump.is_open())
             return 1;
         e.get_gs().reset();
-        e.get_gs().load_state(gsdump);
+        //e.get_gs().load_state(gsdump);
 
         printf("loaded gsdump\n");
         gsdump_reading = true;
@@ -198,8 +198,7 @@ void EmuThread::gsdump_run()
                         Errors::die("gsdump ended before end of file!");
                     gsdump.close();
                     Errors::die("gsdump ended successfully\n");
-                case save_state_t:
-                case load_state_t:
+                case do_state_t:
                     Errors::die("save_state save/load during gsdump not supported!");
                 default:
                     e.get_gs().send_message(data);

--- a/src/qt/emuthread.cpp
+++ b/src/qt/emuthread.cpp
@@ -113,11 +113,13 @@ bool EmuThread::gsdump_read(const char *name)
 {
     wait_for_lock([=]() 
     { 
-        gsdump.open(name,ios::binary);
+        gsdump.open(name, ios::binary | ios::in);
         if (!gsdump.is_open())
             return 1;
         e.get_gs().reset();
-        //e.get_gs().load_state(gsdump);
+
+        auto gsdump_reader = StateSerializer(gsdump, StateSerializer::Mode::Read);
+        e.get_gs().do_state(gsdump_reader);
 
         printf("loaded gsdump\n");
         gsdump_reading = true;

--- a/src/qt/emuthread.hpp
+++ b/src/qt/emuthread.hpp
@@ -31,7 +31,7 @@ class EmuThread : public QThread
         Emulator e;
 
         std::chrono::system_clock::time_point old_frametime;
-        std::ifstream gsdump;
+        std::fstream gsdump;
         std::atomic_bool gsdump_reading;
         std::atomic_bool block_run_loop;
         GSMessage* gsdump_read_buffer;


### PR DESCRIPTION
Wrapped savestate reading/wrapping in a class like duckstation does to avoid having to manage two functions per system.

Seems to work about as well as previously.