### PR TITLE
CI improvements

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,6 +13,7 @@ on:
       - '.github/*_TEMPLATE/**'
       - '*.md'
       - '*.yml'
+  workflow_dispatch:
 
 jobs:
   Windows:
@@ -24,27 +25,27 @@ jobs:
       matrix:
         Configuration: [Release Optimized, Release, Debug, Devel]
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - uses: jurplel/install-qt-action@v2
-    - uses: microsoft/setup-msbuild@v1
-    - name: Build
-      env:
-        QTDIR: ${{ env.Qt5_Dir }}
-      run: msbuild DobieStation\DobieStation.sln /m /nologo /p:Configuration="${{ matrix.Configuration }}"
-    - name: Prepare artifacts
-      if: matrix.Configuration != 'Release'
-      run: Move-Item LICENSE build\bin
-    - name: Upload artifacts
-      if: matrix.Configuration != 'Release'
-      uses: actions/upload-artifact@v2
-      with:
-        name: DobieStation-${{ runner.os }}-${{ matrix.Configuration }}
-        path: |
-          build\bin
-          !**\*.lib
-        if-no-files-found: error
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: jurplel/install-qt-action@v2
+      - uses: microsoft/setup-msbuild@v1
+      - name: Build
+        env:
+          QTDIR: ${{ env.Qt5_Dir }}
+        run: msbuild DobieStation\DobieStation.sln /m /nologo /p:Configuration="${{ matrix.Configuration }}"
+      - name: Prepare artifacts
+        if: matrix.Configuration != 'Release'
+        run: Copy-Item LICENSE build\bin
+      - name: Upload artifacts
+        if: matrix.Configuration != 'Release'
+        uses: actions/upload-artifact@v2
+        with:
+          name: DobieStation-${{ runner.os }}-${{ matrix.Configuration }}
+          path: |
+            build\bin
+            !**\*.lib
+          if-no-files-found: error
 
   Windows-CMake:
     runs-on: windows-latest
@@ -55,20 +56,16 @@ jobs:
       matrix:
         Configuration: [Release, RelWithDebInfo, Debug]
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - uses: jurplel/install-qt-action@v2
-    - name: CMake generate
-      run: |
-        mkdir build
-        cd build
-        cmake ..
-    - name: Build
-      working-directory: build
-      env:
-        QTDIR: ${{ env.Qt5_Dir }}
-      run: cmake --build . --config ${{ matrix.Configuration }} -j $env:NUMBER_OF_PROCESSORS
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: jurplel/install-qt-action@v2
+      - name: CMake generate
+        run: cmake -B build
+      - name: Build
+        env:
+          QTDIR: ${{ env.Qt5_Dir }}
+        run: cmake --build build --config ${{ matrix.Configuration }} -j $env:NUMBER_OF_PROCESSORS
 
   Linux-CMake:
     runs-on: ubuntu-latest
@@ -77,45 +74,44 @@ jobs:
       matrix:
         Configuration: [Release, RelWithDebInfo, Debug]
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Install Qt
-      run: |
-        sudo apt-get update -qq
-        sudo apt-get install -qq qt5-default qtmultimedia5-dev libglu1-mesa-dev
-        mkdir build
-    - name: Build
-      working-directory: build
-      run: |
-        cmake .. -DCMAKE_BUILD_TYPE=${{ matrix.Configuration }}
-        make -j$(nproc)
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install Qt
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -qq qt5-default qtmultimedia5-dev
+      - name: Build
+        run: |
+          cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.Configuration }}
+          cd build
+          make -j$(nproc)
 
   Linux-qmake:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Install Qt
-      run: |
-        sudo apt-get update -qq
-        sudo apt-get install -qq qt5-default qtmultimedia5-dev libglu1-mesa-dev
-    - name: Build
-      working-directory: DobieStation
-      run: |
-        qmake DobieStation.pro
-        make -j$(nproc)
-    - name: Prepare artifacts
-      run: |
-        mkdir artifacts
-        mv LICENSE DobieStation/DobieStation artifacts
-    - name: Upload artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: DobieStation-${{ runner.os }}
-        path: artifacts
-        if-no-files-found: error
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install Qt
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -qq qt5-default qtmultimedia5-dev
+      - name: Build
+        working-directory: DobieStation
+        run: |
+          qmake DobieStation.pro
+          make -j$(nproc)
+      - name: Prepare artifacts
+        run: |
+          mkdir artifacts
+          cp LICENSE DobieStation/DobieStation artifacts
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: DobieStation-${{ runner.os }}
+          path: artifacts
+          if-no-files-found: error
 
   macOS-CMake:
     runs-on: macos-latest
@@ -124,46 +120,45 @@ jobs:
       matrix:
         Configuration: [Release, RelWithDebInfo, Debug]
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Install Qt
-      env:
-        HOMEBREW_NO_ANALYTICS: 1
-      run: |
-        brew install qt@5
-        brew link qt@5 --force
-        mkdir build
-    - name: Build
-      working-directory: build
-      run: |
-        cmake .. -DCMAKE_BUILD_TYPE=${{ matrix.Configuration }} -DCMAKE_PREFIX_PATH=/usr/local/opt/qt5
-        make -j$(sysctl -n hw.ncpu)
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install Qt
+        env:
+          HOMEBREW_NO_ANALYTICS: 1
+        run: |
+          brew install qt@5
+          brew link qt@5 --force
+      - name: Build
+        run: |
+          cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.Configuration }} -DCMAKE_PREFIX_PATH=/usr/local/opt/qt5
+          cd build
+          make -j$(sysctl -n hw.availcpu)
 
   macOS-qmake:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - name: Install Qt
-      env:
-        HOMEBREW_NO_ANALYTICS: 1
-      run: |
-        brew install qt@5
-        brew link qt@5 --force
-    - name: Build
-      working-directory: DobieStation
-      run: |
-        qmake DobieStation.pro
-        make -j$(sysctl -n hw.ncpu)
-    - name: Prepare artifacts
-      run: |
-        mkdir artifacts
-        mv LICENSE DobieStation/DobieStation artifacts
-    - name: Upload artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: DobieStation-${{ runner.os }}
-        path: artifacts
-        if-no-files-found: error
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Install Qt
+        env:
+          HOMEBREW_NO_ANALYTICS: 1
+        run: |
+          brew install qt@5
+          brew link qt@5 --force
+      - name: Build
+        working-directory: DobieStation
+        run: |
+          qmake DobieStation.pro
+          make -j$(sysctl -n hw.availcpu)
+      - name: Prepare artifacts
+        run: |
+          mkdir artifacts
+          cp LICENSE DobieStation/DobieStation artifacts
+      - name: Upload artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: DobieStation-${{ runner.os }}
+          path: artifacts
+          if-no-files-found: error


### PR DESCRIPTION
Add workflow_dispatch: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
Formatting.
Copy instead of moving artifacts.
Use cmake -B instead of mkdir.
Remove redundant package. (libglu1-mesa-dev)
Replace deprecated ncpu with availcpu.