### PR TITLE
Prevent calling delete[] on uninitialised pointer

### DIFF
--- a/src/core/gs.cpp
+++ b/src/core/gs.cpp
@@ -15,7 +15,8 @@ registers.
 
 GraphicsSynthesizer::GraphicsSynthesizer(INTC* intc) 
     : intc(intc), frame_complete(false),
-    output_buffer1(nullptr), output_buffer2(nullptr)
+    output_buffer1(nullptr), output_buffer2(nullptr),
+    gs_download_buffer(nullptr)
 {
 }
 


### PR DESCRIPTION
If you immediately open and close DobieStation, `gs_download_buffer` is never initialised. So when the destructor is called for `GraphicsSynthesizer`, an exception is thrown. This PR fixes this by initialising `gs_download_buffer` to a `nullptr`.